### PR TITLE
Virtual Atom::get_mass

### DIFF
--- a/include/core/data/record/Atom.h
+++ b/include/core/data/record/Atom.h
@@ -281,7 +281,7 @@ namespace data::record {
              * 
              * @return The mass in u.
              */
-            double get_mass() const;
+            virtual double get_mass() const;
 
             /**
              * @brief Get the atomic group this Atom belongs to.

--- a/include/core/data/record/Water.h
+++ b/include/core/data/record/Water.h
@@ -9,6 +9,8 @@ namespace data::record {
             Water(Atom&& a) noexcept;
             Water(const Atom& a);
 
+            double get_mass() const override;
+
             RecordType get_type() const override;
 
             std::string get_recName() const override;

--- a/source/core/data/record/Water.cpp
+++ b/source/core/data/record/Water.cpp
@@ -9,12 +9,14 @@ For more information, please refer to the LICENSE file in the project root.
 
 using namespace data::record;
 
-Water::Water(Atom&& a) noexcept : Atom(std::move(a)) {}
-Water::Water(const Atom& a) : Atom(a) {}
+Water::Water(Atom&& a) noexcept : Atom(std::move(a)) {set_residue_name("HOH");}
+Water::Water(const Atom& a) : Atom(a) {set_residue_name("HOH");}
 
 RecordType Water::get_type() const {return RecordType::WATER;}
 
 std::string Water::get_recName() const {return "HETATM";}
+
+double Water::get_mass() const {return constants::mass::get_mass(constants::atom_t::O) + 2*constants::mass::get_mass(constants::atom_t::H);}
 
 bool Water::is_water() const {return true;}
 

--- a/tests/data/water.cpp
+++ b/tests/data/water.cpp
@@ -21,7 +21,7 @@ TEST_CASE_METHOD(fixture, "Water::Water") {
         CHECK(w1.serial == 1);
         CHECK(w1.name == "C");
         CHECK(w1.altLoc == "");
-        CHECK(w1.resName == "LYS");
+        CHECK(w1.resName == "HOH");
         CHECK(w1.chainID == 'A');
         CHECK(w1.resSeq == 1);
         CHECK(w1.iCode == "");
@@ -38,7 +38,7 @@ TEST_CASE_METHOD(fixture, "Water::Water") {
         CHECK(w1.serial == 1);
         CHECK(w1.name == "C");
         CHECK(w1.altLoc == "");
-        CHECK(w1.resName == "LYS");
+        CHECK(w1.resName == "HOH");
         CHECK(w1.chainID == 'A');
         CHECK(w1.resSeq == 1);
         CHECK(w1.iCode == "");
@@ -66,6 +66,10 @@ TEST_CASE_METHOD(fixture, "Water::Water") {
         CHECK(w2.charge == "0");
         CHECK(w2.is_water() == true);
     }
+}
+
+TEST_CASE_METHOD(fixture, "Water::get_mass") {
+    CHECK(w1.get_mass() == constants::mass::get_mass(constants::atom_t::O) + 2*constants::mass::get_mass(constants::atom_t::H));
 }
 
 TEST_CASE_METHOD(fixture, "Water::get_type") {


### PR DESCRIPTION
Made Atom::get_mass virtual to avoid downloading the HOH RCSB file to determine the mass of water molecules. 