### PR TITLE
Schaefer vols

### DIFF
--- a/executable/saxs_fitter.cpp
+++ b/executable/saxs_fitter.cpp
@@ -31,28 +31,44 @@ int main(int argc, char const *argv[]) {
     app.add_option("input_m", mfile, "Path to the measured data.")->required()->check(CLI::ExistingFile);
     app.add_option("--output,-o", settings::general::output, "Path to save the generated figures at.")->default_val("output/saxs_fitter/")->group("General options");
     app.add_option("--threads,-t", settings::general::threads, "Number of threads to use.")->default_val(settings::general::threads)->group("General options");
-    app.add_option_function<std::string>("--unit,-u", [] (const std::string& s) {settings::detail::parse_option("unit", {s});}, "The unit of the q values in the measurement file. Options: A, nm.")->group("General options");
+    app.add_option_function<std::string>("--unit,-u", [] (const std::string& s) {settings::detail::parse_option("unit", {s});}, 
+        "The unit of the q values in the measurement file. Options: A, nm.")->group("General options");
     app.add_option("--qmax", settings::axes::qmax, "Upper limit on used q values from the measurement file.")->default_val(settings::axes::qmax)->group("General options");
     app.add_option("--qmin", settings::axes::qmin, "Lower limit on used q values from the measurement file.")->default_val(settings::axes::qmin)->group("General options");
     auto p_settings = app.add_option("-s,--settings", settings, "Path to the settings file.")->check(CLI::ExistingFile)->group("General options");
     app.add_flag_callback("--licence", [] () {std::cout << constants::licence << std::endl; exit(0);}, "Print the licence.");
 
     // protein options group
-    app.add_flag("--center,!--no-center", settings::molecule::center, "Decides whether the protein will be centered.")->default_val(settings::molecule::center)->group("Protein options");
-    app.add_flag("--effective-charge,!--no-effective-charge", settings::molecule::use_effective_charge, "Decides whether the effective atomic charge will be used.")->default_val(settings::molecule::use_effective_charge)->group("Protein options");
-    app.add_flag("--keep-hydration,!--discard-hydration", use_existing_hydration, "Decides whether the hydration layer will be generated from scratch or if the existing one will be used.")->default_val(use_existing_hydration)->group("Protein options");
-    app.add_flag("--fit-excluded-volume,!--no-fit-excluded-volume", settings::hist::fit_excluded_volume, "Decides whether the excluded volume will be fitted.")->default_val(settings::hist::fit_excluded_volume)->group("Protein options");
-    app.add_flag("--use-occupancy,!--ignore-occupancy", settings::molecule::use_occupancy, "Decides whether the atomic occupancies from the file will be used.")->default_val(settings::molecule::use_occupancy)->group("Protein options");
+    app.add_flag("--center,!--no-center", settings::molecule::center, 
+        "Decides whether the protein will be centered.")->default_val(settings::molecule::center)->group("Protein options");
+    app.add_flag("--effective-charge,!--no-effective-charge", settings::molecule::use_effective_charge, 
+        "Decides whether the effective atomic charge will be used.")->default_val(settings::molecule::use_effective_charge)->group("Protein options");
+    app.add_flag("--keep-hydration,!--discard-hydration", use_existing_hydration, 
+        "Decides whether the hydration layer will be generated from scratch or if the existing one will be used.")->default_val(use_existing_hydration)->group("Protein options");
+    app.add_flag("--fit-excluded-volume,!--no-fit-excluded-volume", settings::hist::fit_excluded_volume, 
+        "Decides whether the excluded volume will be fitted.")->default_val(settings::hist::fit_excluded_volume)->group("Protein options");
+    app.add_flag("--use-occupancy,!--ignore-occupancy", settings::molecule::use_occupancy, 
+        "Decides whether the atomic occupancies from the file will be used.")->default_val(settings::molecule::use_occupancy)->group("Protein options");
 
     // advanced options group
-    app.add_option("--reduce,-r", settings::grid::water_scaling, "The desired number of water molecules as a percentage of the number of atoms. Use 0 for no reduction.")->default_val(settings::grid::water_scaling)->group("Advanced options");
-    app.add_option("--grid_width,--gw", settings::grid::width, "The distance between each grid point in Ångström. Lower widths increase the precision.")->default_val(settings::grid::width)->group("Advanced options");
-    app.add_option_function<std::string>("--hydration-strategy,--hs", [] (const std::string& s) {settings::detail::parse_option("hydration_strategy", {s});}, "The hydration model to use. Options: Radial, Axes, Jan.")->group("Advanced options");
-    app.add_option("--exv_radius,--er", settings::grid::exv_radius, "The radius of the excluded volume sphere used for the grid-based excluded volume calculations in Ångström.")->default_val(settings::grid::exv_radius)->group("Advanced options");
-    app.add_option_function<std::string>("--histogram-manager,--hm", [] (const std::string& s) {settings::detail::parse_option("histogram_manager", {s});}, "The histogram manager to use. Options: HM, HMMT, HMMTFF, PHM, PHMMT, PHMMTFF.")->group("Advanced options");
-    app.add_flag("--exit-on-unknown-atom,!--no-exit-on-unknown-atom", settings::molecule::throw_on_unknown_atom, "Decides whether the program will exit if an unknown atom is encountered.")->default_val(settings::molecule::throw_on_unknown_atom)->group("Advanced options");
-    app.add_flag("--implicit-hydrogens,!--no-implicit-hydrogens", settings::molecule::implicit_hydrogens, "Decides whether implicit hydrogens will be added to the structure.")->default_val(settings::molecule::implicit_hydrogens)->group("Advanced options");
-    app.add_flag("--keep-hydrogens,!--discard-hydrogens", settings::general::keep_hydrogens, "Decides whether hydrogens will be kept in the structure.")->default_val(settings::general::keep_hydrogens)->group("Advanced options");
+    app.add_option("--reduce,-r", settings::grid::water_scaling, 
+        "The desired number of water molecules as a percentage of the number of atoms. Use 0 for no reduction.")->default_val(settings::grid::water_scaling)->group("Advanced options");
+    app.add_option("--grid_width,--gw", settings::grid::width, 
+        "The distance between each grid point in Ångström. Lower widths increase the precision.")->default_val(settings::grid::width)->group("Advanced options");
+    app.add_option_function<std::string>("--hydration-strategy,--hs", [] (const std::string& s) {settings::detail::parse_option("hydration_strategy", {s});}, 
+        "The hydration model to use. Options: Radial, Axes, Jan.")->group("Advanced options");
+    app.add_option("--exv_radius,--er", settings::grid::exv_radius, 
+        "The radius of the excluded volume sphere used for the grid-based excluded volume calculations in Ångström.")->default_val(settings::grid::exv_radius)->group("Advanced options");
+    app.add_option_function<std::string>("--histogram-manager,--hm", [] (const std::string& s) {settings::detail::parse_option("histogram_manager", {s});}, 
+        "The histogram manager to use. Options: HM, HMMT, HMMTFF, PHM, PHMMT, PHMMTFF.")->group("Advanced options");
+    app.add_flag("--exit-on-unknown-atom,!--no-exit-on-unknown-atom", settings::molecule::throw_on_unknown_atom, 
+        "Decides whether the program will exit if an unknown atom is encountered.")->default_val(settings::molecule::throw_on_unknown_atom)->group("Advanced options");
+    app.add_flag("--implicit-hydrogens,!--no-implicit-hydrogens", settings::molecule::implicit_hydrogens, 
+        "Decides whether implicit hydrogens will be added to the structure.")->default_val(settings::molecule::implicit_hydrogens)->group("Advanced options");
+    app.add_flag("--keep-hydrogens,!--discard-hydrogens", settings::general::keep_hydrogens, 
+        "Decides whether hydrogens will be kept in the structure.")->default_val(settings::general::keep_hydrogens)->group("Advanced options");
+    app.add_option_function<std::string>("--exv-volumes,--exv-volume", [] (const std::string& s) {settings::detail::parse_option("exv_volume", {s});}, 
+        "The set of displaced volumes to use. Options: Traube, Voronoi_implicit_H, Voronoi_explicit_H, MinimumFluctutation_implicit_H, MinimumFluctutation_explicit_H, vdw.")->group("Advanced options");
 
     // hidden options group
     app.add_option("--rvol", settings::grid::rvol, "The radius of the excluded volume sphere around each atom.")->default_val(settings::grid::rvol)->group("");

--- a/include/core/form_factor/DisplacedVolumeTable.h
+++ b/include/core/form_factor/DisplacedVolumeTable.h
@@ -6,82 +6,127 @@
 #include <constants/ConstantsMath.h>
 
 #define TRAUBE false
-#define SCHAEFER true
+#define VORONOI true
+#define MINIMUM_FLUCTUATION true
 namespace constants::displaced_volume {
-    namespace {
+    namespace detail {
+        struct DisplacedVolumeSet {
+            double H;
+            double C, CH, CH2, CH3;
+            double N, NH, NH2, NH3;
+            double O, OH;
+            double S, SH;
+        };
+
         constexpr double volume(double radius) {
             return 4*constants::pi/3*constexpr_math::pow(radius, 3);
         }
     }
 
-    #if TRAUBE
-        // from original CRYSOL paper, 1995: https://doi.org/10.1107/S0021889895007047
-        constexpr double CH  = 0.02159*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double CH2 = 0.02674*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double CH3 = 0.03189*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double NH  = 0.00764*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double NH2 = 0.01279*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double NH3 = 0.01794*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double OH  = 0.01428*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double SH  = 0.02510*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
+    // from original CRYSOL paper, 1995: https://doi.org/10.1107/S0021889895007047
+    constexpr detail::DisplacedVolumeSet Traube {
+        .H   = 0.01986*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3),
+        .C   = 0.02159*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .CH  = 0.02674*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .CH2 = 0.03189*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .CH3 = 0.00764*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .N   = 0.01279*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .NH  = 0.01794*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .NH2 = 0.01428*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .NH3 = 0.02510*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .O   = 0.00515*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .OH  = 0.01644*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .S   = 0.00249*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3), 
+        .SH  = 0.00913*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3)
+    };
 
-        constexpr double H = 0.00515*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double C = 0.01644*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double N = 0.00249*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double O = 0.00913*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double S = 0.01986*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
+    // table I, V^vor from Schaefer et al, 2001: https://doi.org/10.1002/JCC.1137
+    constexpr detail::DisplacedVolumeSet Voronoi_implicit_H {
+        .H   = 0,
+        .C   = 8.895,
+        .CH  = 12.430,
+        .CH2 = 22.033,
+        .CH3 = 34.092,
+        .N   = 9.558,
+        .NH  = 14.944,
+        .NH2 = 22.129,
+        .NH3 = 20.641,
+        .O   = 22.315,
+        .OH  = 23.266,
+        .S   = 26.356,
+        .SH  = 34.192
+    };
 
-    #elif SCHAEFER
-        // table I from Schaefer et al, 2001: https://doi.org/10.1002/JCC.1137
-        constexpr double CH  = 12.430;
-        constexpr double CH2 = 22.033;
-        constexpr double CH3 = 34.092;
-        constexpr double NH  = 14.944;
-        constexpr double NH2 = 22.129;
-        constexpr double NH3 = 20.641;
-        constexpr double OH  = 23.266;
-        constexpr double SH  = 34.192;
+    // table I, V^mf from Schaefer et al, 2001: https://doi.org/10.1002/JCC.1137
+    constexpr detail::DisplacedVolumeSet MinimumFluctuation_implicit_H {
+        .H   = 0,
+        .C   = 12.352,
+        .CH  = 11.640,
+        .CH2 = 34.583,
+        .CH3 = 41.851,
+        .N   = 0.027,
+        .NH  = 2.181,
+        .NH2 = 20.562,
+        .NH3 = 20.722,
+        .O   = 14.238,
+        .OH  = 20.911,
+        .S   = 15.413,
+        .SH  = 28.529
+    };
 
-        constexpr double H   = volume(constants::radius::vdw::H);
-        constexpr double C   = 8.895;
-        constexpr double N   = 9.558;
-        constexpr double O   = 22.315;
-        constexpr double S   = 26.356;
+    // table I, V^vor_H from Schaefer et al, 2001: https://doi.org/10.1002/JCC.1137
+    constexpr detail::DisplacedVolumeSet Voronoi_explicit_H {
+        .H   = 12.958,
+        .C   = 8.658,
+        .CH  = 11.784,
+        .CH2 = 20.682,
+        .CH3 = 33.175,
+        .N   = 9.144,
+        .NH  = 7.119,
+        .NH2 = 5.859,
+        .NH3 = 2.588,
+        .O   = 19.167,
+        .OH  = 13.099,
+        .S   = 25.715,
+        .SH  = 32.333
+    };
 
-    #elif PONTIUS
-        // from Pontius et al, 1996: https://doi.org/10.1006/jmbi.1996.0628
-        constexpr double CH = 11.8;
-        constexpr double CH2 = 20.9;
-        constexpr double CH3 = 33.9;
-        constexpr double NH = 14.1;
-        constexpr double NH2 = 24.6;
-        constexpr double NH3 = 23;
-        constexpr double OH = 23;
-        constexpr double SH = 34.2;
+    // table I, V^mf_H from Schaefer et al, 2001: https://doi.org/10.1002/JCC.1137
+    constexpr detail::DisplacedVolumeSet MinimumFluctuation_explicit_H {
+        .H   = 0.347,
+        .C   = 12.734,
+        .CH  = 11.399,
+        .CH2 = 34.828,
+        .CH3 = 42.011,
+        .N   = 0.018,
+        .NH  = 1.451,
+        .NH2 = 19.064,
+        .NH3 = 17.498,
+        .O   = 14.334,
+        .OH  = 20.312,
+        .S   = 15.242,
+        .SH  = 28.475
+    };
 
-        constexpr double H = 0.00515*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
-        constexpr double C = 8.4;
-        constexpr double N = 8.8;
-        constexpr double O = 22.3;
-        constexpr double S = 25;
+    // based on the van der waals radii of each atom
+    constexpr detail::DisplacedVolumeSet vdw {
+        .H   = detail::volume(constants::radius::vdw::H),
+        .C   = detail::volume(constants::radius::vdw::C),
+        .CH  = detail::volume(constants::radius::vdw::C) + 1*detail::volume(constants::radius::vdw::H),
+        .CH2 = detail::volume(constants::radius::vdw::C) + 2*detail::volume(constants::radius::vdw::H),
+        .CH3 = detail::volume(constants::radius::vdw::C) + 3*detail::volume(constants::radius::vdw::H),
+        .N   = detail::volume(constants::radius::vdw::N),
+        .NH  = detail::volume(constants::radius::vdw::N) + 1*detail::volume(constants::radius::vdw::H),
+        .NH2 = detail::volume(constants::radius::vdw::N) + 2*detail::volume(constants::radius::vdw::H),
+        .NH3 = detail::volume(constants::radius::vdw::N) + 3*detail::volume(constants::radius::vdw::H),
+        .O   = detail::volume(constants::radius::vdw::O),
+        .OH  = detail::volume(constants::radius::vdw::O) + detail::volume(constants::radius::vdw::H),
+        .S   = detail::volume(constants::radius::vdw::S),
+        .SH  = detail::volume(constants::radius::vdw::S) + detail::volume(constants::radius::vdw::H)
+    };
 
-    #else 
-        constexpr double CH = volume(constants::radius::vdw::C) + volume(constants::radius::vdw::H);
-        constexpr double CH2 = volume(constants::radius::vdw::C) + 2*volume(constants::radius::vdw::H);
-        constexpr double CH3 = volume(constants::radius::vdw::C) + 3*volume(constants::radius::vdw::H);
-        constexpr double NH = volume(constants::radius::vdw::N) + volume(constants::radius::vdw::H);
-        constexpr double NH2 = volume(constants::radius::vdw::N) + 2*volume(constants::radius::vdw::H);
-        constexpr double NH3 = volume(constants::radius::vdw::N) + 3*volume(constants::radius::vdw::H);
-        constexpr double OH = volume(constants::radius::vdw::O) + volume(constants::radius::vdw::H);
-        constexpr double SH = volume(constants::radius::vdw::S) + volume(constants::radius::vdw::H);
-
-        constexpr double H = volume(constants::radius::vdw::H);
-        constexpr double C = volume(constants::radius::vdw::C);
-        constexpr double N = volume(constants::radius::vdw::N);
-        constexpr double O = volume(constants::radius::vdw::O);
-        constexpr double S = volume(constants::radius::vdw::S);
-    #endif
-    constexpr double avg_vol = 50./3;
+    //! Remember to update settings::molecule::DisplacedVolumeSet::Default if this is changed
+    inline const detail::DisplacedVolumeSet& standard = Voronoi_implicit_H;
     constexpr double OH2 = 2.98*constexpr_math::pow(10., -23)*constexpr_math::pow(constants::SI::length::cm/constants::SI::length::A, 3);
-    constexpr double Ar = volume(constants::radius::vdw::Ar);
+    constexpr double Ar = detail::volume(constants::radius::vdw::Ar);
 }

--- a/include/core/form_factor/DisplacedVolumeTable.h
+++ b/include/core/form_factor/DisplacedVolumeTable.h
@@ -5,8 +5,8 @@
 #include <math/ConstexprMath.h>
 #include <constants/ConstantsMath.h>
 
-#define TRAUBE_FF false
-#define PONTIUS_FF true
+#define TRAUBE false
+#define SCHAEFER true
 namespace constants::displaced_volume {
     namespace {
         constexpr double volume(double radius) {
@@ -14,8 +14,8 @@ namespace constants::displaced_volume {
         }
     }
 
-    #if TRAUBE_FF
-        // from original CRYSOL paper: https://doi.org/10.1107/S0021889895007047
+    #if TRAUBE
+        // from original CRYSOL paper, 1995: https://doi.org/10.1107/S0021889895007047
         constexpr double CH  = 0.02159*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
         constexpr double CH2 = 0.02674*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
         constexpr double CH3 = 0.03189*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
@@ -31,7 +31,24 @@ namespace constants::displaced_volume {
         constexpr double O = 0.00913*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
         constexpr double S = 0.01986*constexpr_math::pow(constants::SI::length::nm/constants::SI::length::A, 3);
 
-    #elif PONTIUS_FF
+    #elif SCHAEFER
+        // table I from Schaefer et al, 2001: https://doi.org/10.1002/JCC.1137
+        constexpr double CH  = 12.430;
+        constexpr double CH2 = 22.033;
+        constexpr double CH3 = 34.092;
+        constexpr double NH  = 14.944;
+        constexpr double NH2 = 22.129;
+        constexpr double NH3 = 20.641;
+        constexpr double OH  = 23.266;
+        constexpr double SH  = 34.192;
+
+        constexpr double H   = volume(constants::radius::vdw::H);
+        constexpr double C   = 8.895;
+        constexpr double N   = 9.558;
+        constexpr double O   = 22.315;
+        constexpr double S   = 26.356;
+
+    #elif PONTIUS
         // from Pontius et al, 1996: https://doi.org/10.1006/jmbi.1996.0628
         constexpr double CH = 11.8;
         constexpr double CH2 = 20.9;

--- a/include/core/form_factor/DisplacedVolumeTable.h
+++ b/include/core/form_factor/DisplacedVolumeTable.h
@@ -126,7 +126,7 @@ namespace constants::displaced_volume {
     };
 
     //! Remember to update settings::molecule::DisplacedVolumeSet::Default if this is changed
-    inline const detail::DisplacedVolumeSet& standard = Voronoi_implicit_H;
+    inline constexpr const detail::DisplacedVolumeSet& standard = Voronoi_implicit_H;
     constexpr double OH2 = 2.98*constexpr_math::pow(10., -23)*constexpr_math::pow(constants::SI::length::cm/constants::SI::length::A, 3);
     constexpr double Ar = detail::volume(constants::radius::vdw::Ar);
 }

--- a/include/core/form_factor/ExvFormFactor.h
+++ b/include/core/form_factor/ExvFormFactor.h
@@ -34,41 +34,46 @@ namespace form_factor {
             double q0 = 1;
     };
 
-    namespace storage::exv {
-        constexpr ExvFormFactor CH  = ExvFormFactor(constants::displaced_volume::CH);
-        constexpr ExvFormFactor CH2 = ExvFormFactor(constants::displaced_volume::CH2);
-        constexpr ExvFormFactor CH3 = ExvFormFactor(constants::displaced_volume::CH3);
-        constexpr ExvFormFactor NH  = ExvFormFactor(constants::displaced_volume::NH);
-        constexpr ExvFormFactor NH2 = ExvFormFactor(constants::displaced_volume::NH2);
-        constexpr ExvFormFactor NH3 = ExvFormFactor(constants::displaced_volume::NH3);
-        constexpr ExvFormFactor OH  = ExvFormFactor(constants::displaced_volume::OH);
-        constexpr ExvFormFactor SH  = ExvFormFactor(constants::displaced_volume::SH);
+    namespace detail {
+        struct ExvFormFactorSet {
+            constexpr ExvFormFactorSet(const constants::displaced_volume::detail::DisplacedVolumeSet& set) : 
+                H(set.H), C(set.C), CH(set.CH), CH2(set.CH2), CH3(set.CH3), 
+                N(set.N), NH(set.NH), NH2(set.NH2), NH3(set.NH3), 
+                O(set.O), OH(set.OH), 
+                S(set.S), SH(set.SH),
+                Ar(constants::displaced_volume::Ar)
+            {}
 
-        constexpr ExvFormFactor H  =  ExvFormFactor(constants::displaced_volume::H);
-        constexpr ExvFormFactor C  =  ExvFormFactor(constants::displaced_volume::C);
-        constexpr ExvFormFactor N  =  ExvFormFactor(constants::displaced_volume::N);
-        constexpr ExvFormFactor O  =  ExvFormFactor(constants::displaced_volume::O);
-        constexpr ExvFormFactor S  =  ExvFormFactor(constants::displaced_volume::S);
-        constexpr ExvFormFactor Ar =  ExvFormFactor(constants::displaced_volume::Ar);
-
-        constexpr ExvFormFactor get_form_factor(form_factor_t type) {
-            switch(type) {
-                case form_factor_t::CH:    return CH;
-                case form_factor_t::CH2:   return CH2;
-                case form_factor_t::CH3:   return CH3;
-                case form_factor_t::NH:    return NH;
-                case form_factor_t::NH2:   return NH2;
-                case form_factor_t::NH3:   return NH3;
-                case form_factor_t::OH:    return OH;
-                case form_factor_t::H:     return H;
-                case form_factor_t::C:     return C;
-                case form_factor_t::N:     return N;
-                case form_factor_t::O:     return O;
-                case form_factor_t::S:     return S;
-                case form_factor_t::SH:    return SH;
-                case form_factor_t::OTHER: return Ar;
-                default: throw std::runtime_error("form_factor::storage::exv::get_exv_form_factor: Invalid form factor type (enum " + std::to_string(static_cast<int>(type)) + ")");
+            constexpr ExvFormFactor get_form_factor(form_factor_t type) const {
+                switch(type) {
+                    case form_factor_t::H:     return H;
+                    case form_factor_t::C:     return C;
+                    case form_factor_t::CH:    return CH;
+                    case form_factor_t::CH2:   return CH2;
+                    case form_factor_t::CH3:   return CH3;
+                    case form_factor_t::N:     return N;
+                    case form_factor_t::NH:    return NH;
+                    case form_factor_t::NH2:   return NH2;
+                    case form_factor_t::NH3:   return NH3;
+                    case form_factor_t::O:     return O;
+                    case form_factor_t::OH:    return OH;
+                    case form_factor_t::S:     return S;
+                    case form_factor_t::SH:    return SH;
+                    case form_factor_t::OTHER: return Ar;
+                    default: throw std::runtime_error("form_factor::detail::ExvFormFactorSet::get_form_factor: Invalid form factor type (enum " + std::to_string(static_cast<int>(type)) + ")");
+                }
             }
-        }
+
+            ExvFormFactor H;
+            ExvFormFactor C, CH, CH2, CH3;
+            ExvFormFactor N, NH, NH2, NH3;
+            ExvFormFactor O, OH;
+            ExvFormFactor S, SH;
+            ExvFormFactor Ar;
+        };
+    }
+
+    namespace storage::exv {
+        constexpr detail::ExvFormFactorSet standard(constants::displaced_volume::standard);
     }
 }

--- a/include/core/hist/intensity_calculator/crysol/CompositeDistanceHistogramCrysol.h
+++ b/include/core/hist/intensity_calculator/crysol/CompositeDistanceHistogramCrysol.h
@@ -21,7 +21,7 @@ namespace hist {
 
         protected:
             double exv_factor(double q) const override;
-            inline static form_factor::storage::atomic::table_t ffaa_table = form_factor::crysol::storage::atomic::generate_table();
+            inline static form_factor::storage::atomic::table_t ffaa_table = form_factor::storage::atomic::get_precalculated_form_factor_table();
             inline static form_factor::storage::cross::table_t  ffax_table = form_factor::crysol::storage::cross::generate_table();
             inline static form_factor::storage::exv::table_t    ffxx_table = form_factor::crysol::storage::exv::generate_table();
     };

--- a/include/core/hist/intensity_calculator/crysol/FormFactorCrysol.h
+++ b/include/core/hist/intensity_calculator/crysol/FormFactorCrysol.h
@@ -9,8 +9,6 @@
 #include <container/ArrayContainer2D.h>
 #include <math/ConstexprMath.h>
 
-#include <algorithm>
-
 namespace form_factor::crysol {
     /**
      * @brief Calculate the excluded volume form factor based on the description from Crysol: https://doi.org/10.1107/S0021889895007047
@@ -39,106 +37,21 @@ namespace form_factor::crysol {
         double q0 = 1;
     };
 
-    struct FormFactorCrysol {
-        constexpr FormFactorCrysol(std::array<double, 5> a, std::array<double, 5> b, double c) : a(a), b(b), c(c) {
-            std::transform(b.begin(), b.end(), this->b.begin(), [](double x) { return x; });
-            f0 = 1./(a[0] + a[1] + a[2] + a[3] + a[4] + c);
-        }
-
-        constexpr double evaluate(double q) const {
-            double sum = 0;
-            for (unsigned int i = 0; i < 5; ++i) {
-                sum += a[i]*constexpr_math::exp(-b[i]*q*q);
-            }
-            return (sum + c)*f0;
-        }
-
-        std::array<double, 5> a;
-        std::array<double, 5> b;
-        double c;
-        double f0 = 1;
-    };
-
     namespace storage {
-        struct atomic {
-            inline static FormFactorCrysol H            = FormFactorCrysol(           constants::form_factor::H::a,           constants::form_factor::H::b,           constants::form_factor::H::c);
-            inline static FormFactorCrysol C            = FormFactorCrysol(           constants::form_factor::C::a,           constants::form_factor::C::b,           constants::form_factor::C::c);
-            inline static FormFactorCrysol N            = FormFactorCrysol(           constants::form_factor::N::a,           constants::form_factor::N::b,           constants::form_factor::N::c);
-            inline static FormFactorCrysol O            = FormFactorCrysol(           constants::form_factor::O::a,           constants::form_factor::O::b,           constants::form_factor::O::c);
-            inline static FormFactorCrysol S            = FormFactorCrysol(           constants::form_factor::S::a,           constants::form_factor::S::b,           constants::form_factor::S::c);
-
-            inline static FormFactorCrysol CH_sp3       = FormFactorCrysol(      constants::form_factor::CH_sp3::a,      constants::form_factor::CH_sp3::b,      constants::form_factor::CH_sp3::c);
-            inline static FormFactorCrysol CH2_sp3      = FormFactorCrysol(     constants::form_factor::CH2_sp3::a,     constants::form_factor::CH2_sp3::b,     constants::form_factor::CH2_sp3::c);
-            inline static FormFactorCrysol CH3_sp3      = FormFactorCrysol(     constants::form_factor::CH3_sp3::a,     constants::form_factor::CH3_sp3::b,     constants::form_factor::CH3_sp3::c);
-            inline static FormFactorCrysol CH_sp2       = FormFactorCrysol(      constants::form_factor::CH_sp2::a,      constants::form_factor::CH_sp2::b,      constants::form_factor::CH_sp2::c);
-            inline static FormFactorCrysol CH_arom      = FormFactorCrysol(     constants::form_factor::CH_arom::a,     constants::form_factor::CH_arom::b,     constants::form_factor::CH_arom::c);
-            inline static FormFactorCrysol OH_alc       = FormFactorCrysol(      constants::form_factor::OH_alc::a,      constants::form_factor::OH_alc::b,      constants::form_factor::OH_alc::c);
-            inline static FormFactorCrysol OH_acid      = FormFactorCrysol(     constants::form_factor::OH_acid::a,     constants::form_factor::OH_acid::b,     constants::form_factor::OH_acid::c);
-            inline static FormFactorCrysol O_res        = FormFactorCrysol(       constants::form_factor::O_res::a,       constants::form_factor::O_res::b,       constants::form_factor::O_res::c);
-            inline static FormFactorCrysol NH           = FormFactorCrysol(          constants::form_factor::NH::a,          constants::form_factor::NH::b,          constants::form_factor::NH::c);
-            inline static FormFactorCrysol NH2          = FormFactorCrysol(         constants::form_factor::NH2::a,         constants::form_factor::NH2::b,         constants::form_factor::NH2::c);
-            inline static FormFactorCrysol NH_plus      = FormFactorCrysol(     constants::form_factor::NH_plus::a,     constants::form_factor::NH_plus::b,     constants::form_factor::NH_plus::c);
-            inline static FormFactorCrysol NH2_plus     = FormFactorCrysol(    constants::form_factor::NH2_plus::a,    constants::form_factor::NH2_plus::b,    constants::form_factor::NH2_plus::c);
-            inline static FormFactorCrysol NH3_plus     = FormFactorCrysol(    constants::form_factor::NH3_plus::a,    constants::form_factor::NH3_plus::b,    constants::form_factor::NH3_plus::c);
-            inline static FormFactorCrysol NH_guanine   = FormFactorCrysol(  constants::form_factor::NH_guanine::a,  constants::form_factor::NH_guanine::b,  constants::form_factor::NH_guanine::c);
-            inline static FormFactorCrysol NH2_guanine  = FormFactorCrysol( constants::form_factor::NH2_guanine::a, constants::form_factor::NH2_guanine::b, constants::form_factor::NH2_guanine::c);
-            inline static FormFactorCrysol SH           = FormFactorCrysol(          constants::form_factor::SH::a,          constants::form_factor::SH::b,          constants::form_factor::SH::c);
-
-            inline static FormFactorCrysol get_form_factor(form_factor_t type) {
-                switch(type) {
-                    case form_factor_t::H:                  return H;
-                    case form_factor_t::C:                  return C;
-                    case form_factor_t::N:                  return N;
-                    case form_factor_t::O:                  return O;
-                    case form_factor_t::S:                  return S;
-                    case form_factor_t::CH:                 return CH_sp3;
-                    case form_factor_t::CH2:                return CH2_sp3;
-                    case form_factor_t::CH3:                return CH3_sp3;
-                    case form_factor_t::NH:                 return NH;
-                    case form_factor_t::NH2:                return NH2;
-                    case form_factor_t::NH3:                return NH3_plus;
-                    case form_factor_t::OH:                 return OH_alc;
-                    case form_factor_t::SH:                 return SH;
-                    case form_factor_t::OTHER:              return O_res;
-                    case form_factor_t::EXCLUDED_VOLUME:    return FormFactorCrysol({0,0,0,0,0}, {0,0,0,0,0}, 0); // unused
-                    default: throw std::runtime_error("form_factor::crysol::storage::atomic::get_form_factor: Invalid form factor type (enum " + std::to_string(static_cast<int>(type)) + ")");
-                }
-            }
-
-            [[maybe_unused]] static form_factor::storage::atomic::table_t generate_table() {
-                container::ArrayContainer2D<PrecalculatedFormFactorProduct, form_factor::get_count(), form_factor::get_count()> table;
-                for (unsigned int i = 0; i < form_factor::get_count(); ++i) {
-                    for (unsigned int j = 0; j < i; ++j) {
-                        table.index(i, j) = PrecalculatedFormFactorProduct(
-                            form_factor::crysol::storage::atomic::get_form_factor(static_cast<form_factor_t>(i)), 
-                            form_factor::crysol::storage::atomic::get_form_factor(static_cast<form_factor_t>(j))
-                        );
-                        table.index(j, i) = table.index(i, j);
-                    }
-                    table.index(i, i) = PrecalculatedFormFactorProduct(
-                        form_factor::crysol::storage::atomic::get_form_factor(static_cast<form_factor_t>(i)), 
-                        form_factor::crysol::storage::atomic::get_form_factor(static_cast<form_factor_t>(i))
-                    );
-                }
-                return table;
-            }
-        };
-
         struct exv {
-            inline static ExvFormFactorCrysol CH  = ExvFormFactorCrysol(constants::displaced_volume::CH);
-            inline static ExvFormFactorCrysol CH2 = ExvFormFactorCrysol(constants::displaced_volume::CH2);
-            inline static ExvFormFactorCrysol CH3 = ExvFormFactorCrysol(constants::displaced_volume::CH3);
-            inline static ExvFormFactorCrysol NH  = ExvFormFactorCrysol(constants::displaced_volume::NH);
-            inline static ExvFormFactorCrysol NH2 = ExvFormFactorCrysol(constants::displaced_volume::NH2);
-            inline static ExvFormFactorCrysol NH3 = ExvFormFactorCrysol(constants::displaced_volume::NH3);
-            inline static ExvFormFactorCrysol OH  = ExvFormFactorCrysol(constants::displaced_volume::OH);
-            inline static ExvFormFactorCrysol SH  = ExvFormFactorCrysol(constants::displaced_volume::SH);
-
-            inline static ExvFormFactorCrysol H  =  ExvFormFactorCrysol(constants::displaced_volume::H);
-            inline static ExvFormFactorCrysol C  =  ExvFormFactorCrysol(constants::displaced_volume::C);
-            inline static ExvFormFactorCrysol N  =  ExvFormFactorCrysol(constants::displaced_volume::N);
-            inline static ExvFormFactorCrysol O  =  ExvFormFactorCrysol(constants::displaced_volume::O);
-            inline static ExvFormFactorCrysol S  =  ExvFormFactorCrysol(constants::displaced_volume::S);
+            inline static ExvFormFactorCrysol H  =  ExvFormFactorCrysol(constants::displaced_volume::Traube.H);
+            inline static ExvFormFactorCrysol C  =  ExvFormFactorCrysol(constants::displaced_volume::Traube.C);
+            inline static ExvFormFactorCrysol CH  = ExvFormFactorCrysol(constants::displaced_volume::Traube.CH);
+            inline static ExvFormFactorCrysol CH2 = ExvFormFactorCrysol(constants::displaced_volume::Traube.CH2);
+            inline static ExvFormFactorCrysol CH3 = ExvFormFactorCrysol(constants::displaced_volume::Traube.CH3);
+            inline static ExvFormFactorCrysol N  =  ExvFormFactorCrysol(constants::displaced_volume::Traube.N);
+            inline static ExvFormFactorCrysol NH  = ExvFormFactorCrysol(constants::displaced_volume::Traube.NH);
+            inline static ExvFormFactorCrysol NH2 = ExvFormFactorCrysol(constants::displaced_volume::Traube.NH2);
+            inline static ExvFormFactorCrysol NH3 = ExvFormFactorCrysol(constants::displaced_volume::Traube.NH3);
+            inline static ExvFormFactorCrysol O  =  ExvFormFactorCrysol(constants::displaced_volume::Traube.O);
+            inline static ExvFormFactorCrysol OH  = ExvFormFactorCrysol(constants::displaced_volume::Traube.OH);
+            inline static ExvFormFactorCrysol S  =  ExvFormFactorCrysol(constants::displaced_volume::Traube.S);
+            inline static ExvFormFactorCrysol SH  = ExvFormFactorCrysol(constants::displaced_volume::Traube.SH);
             inline static ExvFormFactorCrysol Ar =  ExvFormFactorCrysol(constants::displaced_volume::Ar);
 
             inline static ExvFormFactorCrysol get_form_factor(form_factor_t type) {
@@ -186,13 +99,13 @@ namespace form_factor::crysol {
                 for (unsigned int i = 0; i < form_factor::get_count_without_excluded_volume(); ++i) {
                     for (unsigned int j = 0; j < i; ++j) {
                         table.index(i, j) = PrecalculatedFormFactorProduct(
-                            atomic::get_form_factor(static_cast<form_factor_t>(i)), 
+                            form_factor::storage::atomic::get_form_factor(static_cast<form_factor_t>(i)), 
                             exv::get_form_factor(static_cast<form_factor_t>(j))
                         );
                         table.index(j, i) = table.index(i, j);
                     }
                     table.index(i, i) = PrecalculatedFormFactorProduct(
-                        atomic::get_form_factor(static_cast<form_factor_t>(i)), 
+                        form_factor::storage::atomic::get_form_factor(static_cast<form_factor_t>(i)), 
                         exv::get_form_factor(static_cast<form_factor_t>(i))
                     );
                 }

--- a/include/core/settings/MoleculeSettings.h
+++ b/include/core/settings/MoleculeSettings.h
@@ -7,6 +7,19 @@ namespace settings {
         extern bool throw_on_unknown_atom;  // Decides whether an exception will be thrown if an unknown atom is encountered.
         extern bool implicit_hydrogens;     // Decides whether implicit hydrogens will be added to the structure.
         extern bool use_occupancy;          // Decides whether the occupancy of the atoms will be ignored.
+
+        enum class DisplacedVolumeSet {
+            Traube,                         // Traube 1895 as used by CRYSOL, Pepsi-SAXS & FoXS
+            Voronoi_implicit_H,             // Voronoi volume with implicit hydrogens
+            Voronoi_explicit_H,             // Voronoi volume with explicit hydrogens
+            MinimumFluctutation_implicit_H, // Minimum fluctuation volume with implicit hydrogens
+            MinimumFluctutation_explicit_H, // Minimum fluctuation volume with explicit hydrogens
+            vdw,                            // Volumes calculated from the van der Waals radii
+
+            //! Remember to update constants::displaced_volume::standard if this is changed
+            Default = Voronoi_implicit_H    // Default displaced volume set
+        };
+        extern DisplacedVolumeSet displaced_volume_set;
     }
 
     namespace hydrate {

--- a/source/core/form_factor/PrecalculatedExvFormFactorProduct.cpp
+++ b/source/core/form_factor/PrecalculatedExvFormFactorProduct.cpp
@@ -4,6 +4,7 @@ For more information, please refer to the LICENSE file in the project root.
 */
 
 #include <form_factor/PrecalculatedExvFormFactorProduct.h>
+#include <settings/MoleculeSettings.h>
 #include <constants/Constants.h>
 
 #if CONSTEXPR_TABLES
@@ -14,51 +15,109 @@ For more information, please refer to the LICENSE file in the project root.
 
 using namespace form_factor;
 
-CONST form_factor::storage::exv::table_t generate_exv_exv_table() {
+CONST form_factor::storage::exv::table_t generate_exv_exv_table(const detail::ExvFormFactorSet& set) {
     form_factor::storage::exv::table_t table;
     for (unsigned int i = 0; i < form_factor::get_count_without_excluded_volume(); ++i) {
         for (unsigned int j = 0; j < i; ++j) {
             table.index(i, j) = PrecalculatedFormFactorProduct(
-                storage::exv::get_form_factor(static_cast<form_factor_t>(i)), 
-                storage::exv::get_form_factor(static_cast<form_factor_t>(j))
+                set.get_form_factor(static_cast<form_factor_t>(i)), 
+                set.get_form_factor(static_cast<form_factor_t>(j))
             );
             table.index(j, i) = table.index(i, j);
         }
         table.index(i, i) = PrecalculatedFormFactorProduct(
-            storage::exv::get_form_factor(static_cast<form_factor_t>(i)), 
-            storage::exv::get_form_factor(static_cast<form_factor_t>(i))
+            set.get_form_factor(static_cast<form_factor_t>(i)), 
+            set.get_form_factor(static_cast<form_factor_t>(i))
         );
     }
     return table;
 }
 
-auto ff_xx_table = generate_exv_exv_table();
 const PrecalculatedFormFactorProduct& form_factor::storage::exv::get_precalculated_form_factor_product(unsigned int i, unsigned int j) noexcept {
-    return ff_xx_table.index(i, j);
+    return get_precalculated_form_factor_table().index(i, j);
 }
 
+auto ff_xx_default_table = generate_exv_exv_table(storage::exv::standard);
 const form_factor::storage::exv::table_t& form_factor::storage::exv::get_precalculated_form_factor_table() noexcept {
-    return ff_xx_table;
+    if (settings::molecule::displaced_volume_set == settings::molecule::DisplacedVolumeSet::Default) {
+        return ff_xx_default_table;
+    }
+    switch (settings::molecule::displaced_volume_set) {
+        case settings::molecule::DisplacedVolumeSet::Traube: {
+            static auto table = generate_exv_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Traube));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::Voronoi_explicit_H: {
+            static auto table = generate_exv_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_explicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::Voronoi_implicit_H: {
+            static auto table = generate_exv_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_implicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::MinimumFluctutation_explicit_H: {
+            static auto table = generate_exv_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_explicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::MinimumFluctutation_implicit_H: {
+            static auto table = generate_exv_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_implicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::vdw: {
+            static auto table = generate_exv_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::vdw));
+            return table;
+        }
+    }
+    return ff_xx_default_table;
 }
 
-CONST form_factor::storage::cross::table_t generate_atom_exv_table() {
+CONST form_factor::storage::cross::table_t generate_atom_exv_table(const detail::ExvFormFactorSet& set) {
     form_factor::storage::cross::table_t table;
     for (unsigned int i = 0; i < form_factor::get_count_without_excluded_volume(); ++i) {
         for (unsigned int j = 0; j < form_factor::get_count_without_excluded_volume(); ++j) {
             table.index(i, j) = PrecalculatedFormFactorProduct(
                 storage::atomic::get_form_factor(static_cast<form_factor_t>(i)), 
-                storage::exv::get_form_factor(static_cast<form_factor_t>(j))
+                set.get_form_factor(static_cast<form_factor_t>(j))
             );
         }
     }
     return table;
 }
 
-auto ff_ax_table = generate_atom_exv_table();
 const PrecalculatedFormFactorProduct& form_factor::storage::cross::get_precalculated_form_factor_product(unsigned int i, unsigned int j) noexcept {
-    return ff_ax_table.index(i, j);
+    return get_precalculated_form_factor_table().index(i, j);
 }
 
+auto ff_ax_default_table = generate_atom_exv_table(storage::exv::standard);
 const form_factor::storage::cross::table_t& form_factor::storage::cross::get_precalculated_form_factor_table() noexcept {
-    return ff_ax_table;
+    if (settings::molecule::displaced_volume_set == settings::molecule::DisplacedVolumeSet::Default) {
+        return ff_ax_default_table;
+    }
+    switch (settings::molecule::displaced_volume_set) {
+        case settings::molecule::DisplacedVolumeSet::Traube: {
+            static auto table = generate_atom_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Traube));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::Voronoi_explicit_H: {
+            static auto table = generate_atom_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_explicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::Voronoi_implicit_H: {
+            static auto table = generate_atom_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_implicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::MinimumFluctutation_explicit_H: {
+            static auto table = generate_atom_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_explicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::MinimumFluctutation_implicit_H: {
+            static auto table = generate_atom_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::Voronoi_implicit_H));
+            return table;
+        }
+        case settings::molecule::DisplacedVolumeSet::vdw: {
+            static auto table = generate_atom_exv_table(detail::ExvFormFactorSet(constants::displaced_volume::vdw));
+            return table;
+        }
+    }
+    return ff_ax_default_table;
 }

--- a/source/core/settings/MoleculeSettings.cpp
+++ b/source/core/settings/MoleculeSettings.cpp
@@ -27,7 +27,8 @@ namespace settings::molecule::io {
         settings::io::create(use_effective_charge, "use_effective_charge"),
         settings::io::create(throw_on_unknown_atom, "throw_on_unknown_atom"),
         settings::io::create(implicit_hydrogens, "implicit_hydrogens"),
-        settings::io::create(use_occupancy, "use_occupancy")
+        settings::io::create(use_occupancy, "use_occupancy"),
+        settings::io::create(displaced_volume_set, "exv_volume")
     });
 
     settings::io::SettingSection hydrate_settings("Hydrate", {
@@ -66,4 +67,30 @@ template<> void settings::io::detail::SettingRef<settings::hydrate::HydrationStr
 template<> std::string settings::io::detail::SettingRef<settings::hydrate::CullingStrategy>::get() const {return std::to_string(static_cast<int>(settingref));}
 template<> void settings::io::detail::SettingRef<settings::hydrate::CullingStrategy>::set(const std::vector<std::string>& val) {
     settingref = static_cast<settings::hydrate::CullingStrategy>(std::stoi(val[0]));
+}
+
+template<> std::string settings::io::detail::SettingRef<settings::molecule::DisplacedVolumeSet>::get() const {
+    switch (settingref) {
+        case settings::molecule::DisplacedVolumeSet::Traube: return "traube";
+        case settings::molecule::DisplacedVolumeSet::Voronoi_implicit_H: return "voronoi_implicit_h";
+        case settings::molecule::DisplacedVolumeSet::Voronoi_explicit_H: return "voronoi_explicit_h";
+        case settings::molecule::DisplacedVolumeSet::MinimumFluctutation_implicit_H: return "minimum_fluctuation_implicit_h";
+        case settings::molecule::DisplacedVolumeSet::MinimumFluctutation_explicit_H: return "minimum_fluctuation_explicit_h";
+        case settings::molecule::DisplacedVolumeSet::vdw: return "vdw";
+        default: return std::to_string(static_cast<int>(settingref));
+    }
+}
+
+template<> void settings::io::detail::SettingRef<settings::molecule::DisplacedVolumeSet>::set(const std::vector<std::string>& val) {
+    auto str = utility::to_lowercase(val[0]); 
+    if (str == "traube") {settingref = settings::molecule::DisplacedVolumeSet::Traube;}
+    else if (str == "voronoi_implicit_h" || str == "voronoi") {settingref = settings::molecule::DisplacedVolumeSet::Voronoi_implicit_H;}
+    else if (str == "voronoi_explicit_h") {settingref = settings::molecule::DisplacedVolumeSet::Voronoi_explicit_H;}
+    else if (str == "minimum_fluctuation_implicit_h" || str == "mf") {settingref = settings::molecule::DisplacedVolumeSet::MinimumFluctutation_implicit_H;}
+    else if (str == "minimum_fluctuation_explicit_h") {settingref = settings::molecule::DisplacedVolumeSet::MinimumFluctutation_explicit_H;}
+    else if (str == "vdw") {settingref = settings::molecule::DisplacedVolumeSet::vdw;}
+    else if (!val[0].empty() && std::isdigit(val[0][0])) {settingref = static_cast<settings::molecule::DisplacedVolumeSet>(std::stoi(val[0]));}
+    else {
+        throw except::io_error("settings::molecule::displaced_volume_set: Unkown DisplacedVolumeSet. Did you forget to add parsing support for it in MoleculeSettings.cpp?");
+    }
 }

--- a/source/core/settings/MoleculeSettings.cpp
+++ b/source/core/settings/MoleculeSettings.cpp
@@ -13,6 +13,8 @@ bool settings::molecule::implicit_hydrogens = true;
 bool settings::molecule::use_effective_charge = true;
 bool settings::molecule::use_occupancy = true;
 
+settings::molecule::DisplacedVolumeSet settings::molecule::displaced_volume_set = settings::molecule::DisplacedVolumeSet::Default;
+
 #if DEBUG
     bool settings::molecule::throw_on_unknown_atom = true;
 #else

--- a/tests/form_factor/exv_form_factors.cpp
+++ b/tests/form_factor/exv_form_factors.cpp
@@ -23,7 +23,7 @@ TEST_CASE("ExvFormFactor::plot", "[manual]") {
     }
 
     for (unsigned int ff = 0; ff < form_factor::get_count_without_excluded_volume(); ++ff) {
-        const form_factor::ExvFormFactor& ff_obj = form_factor::storage::exv::get_form_factor(static_cast<form_factor::form_factor_t>(ff));
+        const form_factor::ExvFormFactor& ff_obj = form_factor::storage::exv::standard.get_form_factor(static_cast<form_factor::form_factor_t>(ff));
         SimpleDataset dataset;
         for (const double& q : q_vals) {
             dataset.push_back(q, ff_obj.evaluate_normalized(q));
@@ -37,7 +37,7 @@ TEST_CASE("ExvFormFactor::plot", "[manual]") {
 TEST_CASE("ExvFormFactor::plot_cmp", "[manual]") {
     for (unsigned int ffi = 0; ffi < form_factor::get_count_without_excluded_volume(); ++ffi) {
         const form_factor::FormFactor& ff = form_factor::storage::atomic::get_form_factor(static_cast<form_factor::form_factor_t>(ffi));
-        const form_factor::ExvFormFactor& ffx = form_factor::storage::exv::get_form_factor(static_cast<form_factor::form_factor_t>(ffi));
+        const form_factor::ExvFormFactor& ffx = form_factor::storage::exv::standard.get_form_factor(static_cast<form_factor::form_factor_t>(ffi));
 
         SimpleDataset dataset, datasetx;
         for (const double& q : q_vals) {

--- a/tests/form_factor/precalculated_exv_form_factor_product.cpp
+++ b/tests/form_factor/precalculated_exv_form_factor_product.cpp
@@ -4,6 +4,7 @@
 #include <form_factor/ExvFormFactor.h>
 #include <form_factor/PrecalculatedFormFactorProduct.h>
 #include <form_factor/PrecalculatedExvFormFactorProduct.h>
+#include <settings/All.h>
 
 using namespace form_factor;
 
@@ -11,8 +12,8 @@ TEST_CASE("PrecalculatedFormFactorProduct::evaluate") {
     SECTION("exv") {
         for (unsigned int ff1 = 0; ff1 < get_count_without_excluded_volume(); ++ff1) {
             for (unsigned int ff2 = 0; ff2 < get_count_without_excluded_volume(); ++ff2) {
-                const ExvFormFactor& ff1_obj = storage::exv::get_form_factor(static_cast<form_factor_t>(ff1));
-                const ExvFormFactor& ff2_obj = storage::exv::get_form_factor(static_cast<form_factor_t>(ff2));
+                const ExvFormFactor& ff1_obj = storage::exv::standard.get_form_factor(static_cast<form_factor_t>(ff1));
+                const ExvFormFactor& ff2_obj = storage::exv::standard.get_form_factor(static_cast<form_factor_t>(ff2));
                 PrecalculatedFormFactorProduct ff(ff1_obj, ff2_obj);
                 for (unsigned int i = 0; i < constants::axes::q_axis.bins; ++i) {
                     REQUIRE_THAT(ff.evaluate(i), Catch::Matchers::WithinRel(ff1_obj.evaluate(constants::axes::q_vals[i])*ff2_obj.evaluate(constants::axes::q_vals[i])));
@@ -25,7 +26,7 @@ TEST_CASE("PrecalculatedFormFactorProduct::evaluate") {
         for (unsigned int ff1 = 0; ff1 < get_count_without_excluded_volume(); ++ff1) {
             for (unsigned int ff2 = 0; ff2 < get_count_without_excluded_volume(); ++ff2) {
                 const FormFactor& ff1_obj = storage::atomic::get_form_factor(static_cast<form_factor_t>(ff1));
-                const ExvFormFactor& ff2_obj = storage::exv::get_form_factor(static_cast<form_factor_t>(ff2));
+                const ExvFormFactor& ff2_obj = storage::exv::standard.get_form_factor(static_cast<form_factor_t>(ff2));
                 PrecalculatedFormFactorProduct ff(ff1_obj, ff2_obj);
                 for (unsigned int i = 0; i < constants::axes::q_axis.bins; ++i) {
                     REQUIRE_THAT(ff.evaluate(i), Catch::Matchers::WithinRel(ff1_obj.evaluate(constants::axes::q_vals[i])*ff2_obj.evaluate(constants::axes::q_vals[i])));
@@ -40,8 +41,8 @@ TEST_CASE("PrecalculatedFormFactorProduct::table") {
         const auto& table = storage::exv::get_precalculated_form_factor_table();
         for (unsigned int ff1 = 0; ff1 < get_count_without_excluded_volume(); ++ff1) {
             for (unsigned int ff2 = 0; ff2 < get_count_without_excluded_volume(); ++ff2) {
-                const ExvFormFactor& ff1_obj = storage::exv::get_form_factor(static_cast<form_factor_t>(ff1));
-                const ExvFormFactor& ff2_obj = storage::exv::get_form_factor(static_cast<form_factor_t>(ff2));
+                const ExvFormFactor& ff1_obj = storage::exv::standard.get_form_factor(static_cast<form_factor_t>(ff1));
+                const ExvFormFactor& ff2_obj = storage::exv::standard.get_form_factor(static_cast<form_factor_t>(ff2));
                 const PrecalculatedFormFactorProduct& ff = table.index(ff1, ff2);
                 for (unsigned int i = 0; i < constants::axes::q_axis.bins; ++i) {
                     REQUIRE_THAT(ff.evaluate(i), Catch::Matchers::WithinRel(ff1_obj.evaluate(constants::axes::q_vals[i])*ff2_obj.evaluate(constants::axes::q_vals[i])));
@@ -55,12 +56,76 @@ TEST_CASE("PrecalculatedFormFactorProduct::table") {
         for (unsigned int ff1 = 0; ff1 < get_count_without_excluded_volume(); ++ff1) {
             for (unsigned int ff2 = 0; ff2 < get_count_without_excluded_volume(); ++ff2) {
                 const FormFactor& ff1_obj = storage::atomic::get_form_factor(static_cast<form_factor_t>(ff1));
-                const ExvFormFactor& ff2_obj = storage::exv::get_form_factor(static_cast<form_factor_t>(ff2));
+                const ExvFormFactor& ff2_obj = storage::exv::standard.get_form_factor(static_cast<form_factor_t>(ff2));
                 const PrecalculatedFormFactorProduct& ff = table.index(ff1, ff2);
                 for (unsigned int i = 0; i < constants::axes::q_axis.bins; ++i) {
                     REQUIRE_THAT(ff.evaluate(i), Catch::Matchers::WithinRel(ff1_obj.evaluate(constants::axes::q_vals[i])*ff2_obj.evaluate(constants::axes::q_vals[i])));
                 }
             }
         }
+    }
+}
+
+TEST_CASE("ExvFormFactor: switch volumes") {
+    auto test = [] (const constants::displaced_volume::detail::DisplacedVolumeSet& vols) {
+        SECTION("exv") {
+            const auto& table = storage::exv::get_precalculated_form_factor_table();
+            auto ffset = form_factor::detail::ExvFormFactorSet(vols);
+            for (unsigned int ff1 = 0; ff1 < get_count_without_excluded_volume(); ++ff1) {
+                for (unsigned int ff2 = 0; ff2 < get_count_without_excluded_volume(); ++ff2) {
+                    const ExvFormFactor& ff1_obj = ffset.get_form_factor(static_cast<form_factor_t>(ff1));
+                    const ExvFormFactor& ff2_obj = ffset.get_form_factor(static_cast<form_factor_t>(ff2));
+                    const PrecalculatedFormFactorProduct& ff = table.index(ff1, ff2);
+                    for (unsigned int i = 0; i < constants::axes::q_axis.bins; ++i) {
+                        REQUIRE_THAT(ff.evaluate(i), Catch::Matchers::WithinRel(ff1_obj.evaluate(constants::axes::q_vals[i])*ff2_obj.evaluate(constants::axes::q_vals[i])));
+                    }
+                }
+            }
+        }
+
+        SECTION("cross") {
+            const auto& table = storage::cross::get_precalculated_form_factor_table();
+            auto ffset = form_factor::detail::ExvFormFactorSet(vols);
+            for (unsigned int ff1 = 0; ff1 < get_count_without_excluded_volume(); ++ff1) {
+                for (unsigned int ff2 = 0; ff2 < get_count_without_excluded_volume(); ++ff2) {
+                    const FormFactor& ff1_obj = storage::atomic::get_form_factor(static_cast<form_factor_t>(ff1));
+                    const ExvFormFactor& ff2_obj = ffset.get_form_factor(static_cast<form_factor_t>(ff2));
+                    const PrecalculatedFormFactorProduct& ff = table.index(ff1, ff2);
+                    for (unsigned int i = 0; i < constants::axes::q_axis.bins; ++i) {
+                        REQUIRE_THAT(ff.evaluate(i), Catch::Matchers::WithinRel(ff1_obj.evaluate(constants::axes::q_vals[i])*ff2_obj.evaluate(constants::axes::q_vals[i])));
+                    }
+                }
+            }
+        }
+    };
+
+    SECTION("Traube") {
+        settings::molecule::displaced_volume_set = settings::molecule::DisplacedVolumeSet::Traube;
+        test(constants::displaced_volume::Traube);
+    }
+
+    SECTION("Voronoi_explicit_H") {
+        settings::molecule::displaced_volume_set = settings::molecule::DisplacedVolumeSet::Voronoi_explicit_H;
+        test(constants::displaced_volume::Voronoi_explicit_H);
+    }
+
+    SECTION("Voronoi_implicit_H") {
+        settings::molecule::displaced_volume_set = settings::molecule::DisplacedVolumeSet::Voronoi_implicit_H;
+        test(constants::displaced_volume::Voronoi_implicit_H);
+    }
+
+    SECTION("MinimumFluctutation_explicit_H") {
+        settings::molecule::displaced_volume_set = settings::molecule::DisplacedVolumeSet::MinimumFluctutation_explicit_H;
+        test(constants::displaced_volume::Voronoi_explicit_H);
+    }
+
+    SECTION("MinimumFluctutation_implicit_H") {
+        settings::molecule::displaced_volume_set = settings::molecule::DisplacedVolumeSet::MinimumFluctutation_implicit_H;
+        test(constants::displaced_volume::Voronoi_implicit_H);
+    }
+
+    SECTION("vdw") {
+        settings::molecule::displaced_volume_set = settings::molecule::DisplacedVolumeSet::vdw;
+        test(constants::displaced_volume::vdw);
     }
 }

--- a/tests/hist/composite_distance_histogram_ff_explicit.cpp
+++ b/tests/hist/composite_distance_histogram_ff_explicit.cpp
@@ -30,7 +30,7 @@ TEST_CASE("CompositeDistanceHistogramFFAvg::debye_transform") {
     settings::molecule::implicit_hydrogens = false;
     auto ff_C = form_factor::storage::atomic::get_form_factor(form_factor::form_factor_t::C);
     auto ff_w = form_factor::storage::atomic::get_form_factor(form_factor::form_factor_t::O);
-    auto ff_Cx = form_factor::storage::exv::get_form_factor(form_factor::form_factor_t::C);
+    auto ff_Cx = form_factor::storage::exv::standard.get_form_factor(form_factor::form_factor_t::C);
     // auto ff_wx = form_factor::storage::exv::get_form_factor(form_factor::form_factor_t::O);
     const auto& q_axis = constants::axes::q_vals;
     std::vector<double> Iq_exp(q_axis.size(), 0);


### PR DESCRIPTION
Replaced the Pontius volumes with those from Schaefer _et al_. 

The excluded volume tables can now be switched at runtime to better support structures containing explicit hydrogens. 