### PR TITLE
Grid settings update

### DIFF
--- a/executable/gui/saxs_fitter_gui/saxs_fitter_gui.cpp
+++ b/executable/gui/saxs_fitter_gui/saxs_fitter_gui.cpp
@@ -94,7 +94,7 @@ auto make_start_button(gui::view& view) {
 			plots::PlotDistance::quick_plot(fitter->get_scattering_hist(), settings::general::output + "p(r)." + settings::plots::format);
 			plots::PlotProfiles::quick_plot(fitter->get_scattering_hist(), settings::general::output + "profiles." + settings::plots::format);
 
-			fitter->get_model_dataset().save(settings::general::output + "fit.fit");
+			fitter->get_model_dataset().save(settings::general::output + "ausaxs.fit");
 			fitter->get_dataset().save(settings::general::output + io::File(settings::saxs_file).stem() + ".scat");
 
 			setup::pdb->save(settings::general::output + "model.pdb");

--- a/executable/gui/saxs_fitter_gui/saxs_fitter_gui.cpp
+++ b/executable/gui/saxs_fitter_gui/saxs_fitter_gui.cpp
@@ -84,8 +84,8 @@ auto make_start_button(gui::view& view) {
 			setup::pdb->generate_new_hydration();
 
 			std::shared_ptr<fitter::HydrationFitter> fitter;
-			if (fit_excluded_volume) {fitter = std::make_shared<fitter::ExcludedVolumeFitter>(settings::saxs_file, setup::pdb->get_histogram());}
-			else {fitter = std::make_shared<fitter::HydrationFitter>(settings::saxs_file, setup::pdb->get_histogram());}
+			if (fit_excluded_volume) {fitter = std::make_shared<fitter::ExcludedVolumeFitter>(io::ExistingFile(settings::saxs_file), setup::pdb->get_histogram());}
+			else {fitter = std::make_shared<fitter::HydrationFitter>(io::ExistingFile(settings::saxs_file), setup::pdb->get_histogram());}
 			auto result = fitter->fit();
 
 			fitter::FitReporter::report(result.get());

--- a/executable/rigidbody_optimizer.cpp
+++ b/executable/rigidbody_optimizer.cpp
@@ -33,7 +33,7 @@ int main(int argc, char const *argv[]) {
     app.add_option("output", settings::general::output, "Path to save the hydrated file at.")->default_val("output/rigidbody/");
     auto p_cal = app.add_option("--calibrate", settings::rigidbody::detail::calibration_file, "Path to the calibration data.")->expected(0, 1)->check(CLI::ExistingFile);
     app.add_option("--reduce,-r", settings::grid::water_scaling, "The desired number of water molecules as a percentage of the number of atoms. Use 0 for no reduction.");
-    app.add_option("--grid_width,-w", settings::grid::width, "The distance between each grid point in Ångström (default: 1). Lower widths increase the precision.");
+    app.add_option("--grid_width,-w", settings::grid::cell_width, "The distance between each grid point in Ångström (default: 1). Lower widths increase the precision.");
     app.add_option_function<std::string>("--placement-strategy,--ps", [] (const std::string& s) {settings::detail::parse_option("placement_strategy", {s});}, "The placement strategy to use. Options: Radial, Axes, Jan.");
     app.add_option("--qmin", settings::axes::qmin, "Lower limit on used q values from measurement file.");
     app.add_option("--qmax", settings::axes::qmax, "Upper limit on used q values from measurement file.");

--- a/executable/saxs_fitter.cpp
+++ b/executable/saxs_fitter.cpp
@@ -53,12 +53,12 @@ int main(int argc, char const *argv[]) {
     // advanced options group
     app.add_option("--reduce,-r", settings::grid::water_scaling, 
         "The desired number of water molecules as a percentage of the number of atoms. Use 0 for no reduction.")->default_val(settings::grid::water_scaling)->group("Advanced options");
-    app.add_option("--grid_width,--gw", settings::grid::width, 
-        "The distance between each grid point in Ångström. Lower widths increase the precision.")->default_val(settings::grid::width)->group("Advanced options");
+    app.add_option("--grid_width,--gw", settings::grid::cell_width, 
+        "The distance between each grid point in Ångström. Lower widths increase the precision.")->default_val(settings::grid::cell_width)->group("Advanced options");
     app.add_option_function<std::string>("--hydration-strategy,--hs", [] (const std::string& s) {settings::detail::parse_option("hydration_strategy", {s});}, 
         "The hydration model to use. Options: Radial, Axes, Jan.")->group("Advanced options");
-    app.add_option("--exv_radius,--er", settings::grid::exv_radius, 
-        "The radius of the excluded volume sphere used for the grid-based excluded volume calculations in Ångström.")->default_val(settings::grid::exv_radius)->group("Advanced options");
+    app.add_option("--exv_radius,--er", settings::grid::exv::radius, 
+        "The radius of the excluded volume sphere used for the grid-based excluded volume calculations in Ångström.")->default_val(settings::grid::exv::radius)->group("Advanced options");
     app.add_option_function<std::string>("--histogram-manager,--hm", [] (const std::string& s) {settings::detail::parse_option("histogram_manager", {s});}, 
         "The histogram manager to use. Options: HM, HMMT, HMMTFF, PHM, PHMMT, PHMMTFF.")->group("Advanced options");
     app.add_flag("--exit-on-unknown-atom,!--no-exit-on-unknown-atom", settings::molecule::throw_on_unknown_atom, 
@@ -71,10 +71,10 @@ int main(int argc, char const *argv[]) {
         "The set of displaced volumes to use. Options: Traube, Voronoi_implicit_H, Voronoi_explicit_H, MinimumFluctutation_implicit_H, MinimumFluctutation_explicit_H, vdw.")->group("Advanced options");
 
     // hidden options group
-    app.add_option("--rvol", settings::grid::rvol, "The radius of the excluded volume sphere around each atom.")->default_val(settings::grid::rvol)->group("");
-    app.add_option("--surface-thickness", settings::grid::surface_thickness, "The thickness of the surface layer in Ångström.")->default_val(settings::grid::surface_thickness)->group("");
+    app.add_option("--rvol", settings::grid::min_exv_radius, "The radius of the excluded volume sphere around each atom.")->default_val(settings::grid::min_exv_radius)->group("");
+    app.add_option("--surface-thickness", settings::grid::exv::surface_thickness, "The thickness of the surface layer in Ångström.")->default_val(settings::grid::exv::surface_thickness)->group("");
     app.add_flag("--weighted-bins", settings::hist::weighted_bins, "Decides whether the weighted bins will be used.")->default_val(settings::hist::weighted_bins)->group("");
-    app.add_flag("--save-exv", settings::grid::save_exv, "Decides whether the excluded volume will be saved.")->default_val(settings::grid::save_exv)->group("");
+    app.add_flag("--save-exv", settings::grid::exv::save, "Decides whether the excluded volume will be saved.")->default_val(settings::grid::exv::save)->group("");
     CLI11_PARSE(app, argc, argv);
 
     console::print_info("Running AUSAXS " + std::string(constants::version));

--- a/include/core/settings/GridSettings.h
+++ b/include/core/settings/GridSettings.h
@@ -3,18 +3,36 @@
 #include <utility/Limit3D.h>
 
 namespace settings::grid {
-    extern double water_scaling; // The number of generated water molecules as a percent of the number of atoms.
-    extern double width;         // Cell width in Ångström. Each grid cell is a cube with sides of this length.
-    extern double scaling;       // The percent increase in grid size in all dimensions when the grid size is automatically deduced based on an input vector of atoms.
-    extern double rvol;          // The radius of the excluded volume sphere around each atom. This does *not* block water placement and *only* affects volume calculations. 
-    extern double exv_radius;    // The radius of the excluded volume sphere used for the grid-based excluded volume calculations in Å.
-    extern double surface_thickness; // The surface thickness of the grid in Ångström. This is used for fitting the excluded volume. 
-    extern bool   save_exv;      // Whether to save the excluded volume grid when using the grid-based excluded volume calculations. This is primarily useful for debugging.
-    extern bool   cubic;         // Whether to generate a cubic grid. This is primarily intended for rigid body optimization, to ensure there's enough space for all possible conformations.
+    // The number of generated water molecules as a percent of the number of atoms.
+    extern double water_scaling;
+
+    // Cell width in Ångström. Each grid cell is a cube with sides of this length.
+    extern double cell_width;
+
+    // The percent increase in grid size in all dimensions when the grid size is automatically deduced based on an input vector of atoms.
+    extern double scaling;
     
+    // The radius of the excluded volume sphere around each atom. This does *not* block water placement and *only* affects volume calculations. 
+    extern double min_exv_radius;
+
+    // Whether to generate a cubic grid. This is primarily intended for rigid body optimization, to ensure there's enough space for all possible conformations.
+    extern bool   cubic;
+
     // The minimum number of bins in each dimension of the grid. 
     // This is primarily intended for rigid body optimization, to ensure there's enough space for all possible conformations. A value of 0 means disabled. 
     extern unsigned int min_bins;
+
+    // Grid-based excluded volume settings.
+    namespace exv {
+        // Whether to save the excluded volume grid when using the grid-based excluded volume calculations. This is primarily useful for debugging.
+        extern bool   save;
+
+        // The radius of the excluded volume sphere used for the grid-based excluded volume calculations in Å.
+        extern double radius;
+
+        // The surface thickness of the grid in Ångström. This is used for fitting the excluded volume. 
+        extern double surface_thickness;
+    }
 
     namespace detail {
         extern double min_score; // (0.5 + min_score) is the minimum percentage of radial lines which must not intersect anything to place a water molecule.

--- a/source/core/grid/detail/GridSurfaceDetection.cpp
+++ b/source/core/grid/detail/GridSurfaceDetection.cpp
@@ -83,8 +83,8 @@ bool GridSurfaceDetection::collision_check(const Vector3<int>& loc) const {
 std::vector<Vector3<double>> GridSurfaceDetection::determine_vacuum_holes() const {
     assert(!grid->w_members.empty() && "grid must first be hydrated to determine vacuum holes");
 
-    int empty_limit = std::round(3*constants::radius::get_vdw_radius(constants::atom_t::O)/settings::grid::width);
-    int stride = std::round(2*settings::grid::exv_radius/settings::grid::width);
+    int empty_limit = std::round(3*constants::radius::get_vdw_radius(constants::atom_t::O)/settings::grid::cell_width);
+    int stride = std::round(2*settings::grid::exv::radius/settings::grid::cell_width);
     auto& gobj = grid->grid;
     auto[vmin, vmax] = grid->bounding_box_index();
     std::vector<Vector3<double>> vacuum_voxels;
@@ -127,8 +127,8 @@ GridExcludedVolume GridSurfaceDetection::helper() const {
     GridExcludedVolume vol;
     vol.interior.reserve(grid->get_volume());
 
-    int stride = std::round(2*settings::grid::exv_radius/settings::grid::width);
-    int buffer = std::round(std::max<double>(settings::grid::rvol, 2)/settings::grid::width);
+    int stride = std::round(2*settings::grid::exv::radius/settings::grid::cell_width);
+    int buffer = std::round(std::max<double>(settings::grid::min_exv_radius, 2)/settings::grid::cell_width);
     const auto& axes = grid->get_axes();
     auto& gobj = grid->grid;
     auto[vmin, vmax] = grid->bounding_box_index();
@@ -165,7 +165,7 @@ GridExcludedVolume GridSurfaceDetection::helper() const {
     }
 
     if constexpr (!unity_width) {
-        int expand = std::round(settings::grid::surface_thickness/settings::grid::width)/2;
+        int expand = std::round(settings::grid::exv::surface_thickness/settings::grid::cell_width)/2;
         int expand2 = expand*expand;
         auto mark_adjacent = [&gobj, expand, expand2] (int i, int j, int k) {
             Vector3<int> origin{i, j, k};
@@ -229,7 +229,7 @@ GridExcludedVolume GridSurfaceDetection::no_detect() const {
 }
 
 GridExcludedVolume GridSurfaceDetection::detect() const {
-    int expand = std::round(settings::grid::surface_thickness/settings::grid::width);
+    int expand = std::round(settings::grid::exv::surface_thickness/settings::grid::cell_width);
     if (expand != 1) {
         return helper<true, false>();
     }

--- a/source/core/hist/intensity_calculator/CompositeDistanceHistogramFFGrid.cpp
+++ b/source/core/hist/intensity_calculator/CompositeDistanceHistogramFFGrid.cpp
@@ -44,7 +44,7 @@ double CompositeDistanceHistogramFFGrid::exv_factor(double) const {
 form_factor::storage::atomic::table_t CompositeDistanceHistogramFFGrid::generate_table() {
     form_factor::storage::atomic::table_t table;
 
-    auto V = std::pow(2*settings::grid::exv_radius, 3);
+    auto V = std::pow(2*settings::grid::exv::radius, 3);
     FormFactor ffx = ExvFormFactor(V);
     // FormFactor ffx({1, 0, 0, 0, 0}, {std::pow(settings::grid::exv_radius, 2)/4, 0, 0, 0, 0}, 0);
     // ffx.set_normalization(V*constants::charge::density::water);

--- a/source/core/hydrate/generation/PepsiHydration.cpp
+++ b/source/core/hydrate/generation/PepsiHydration.cpp
@@ -97,11 +97,11 @@ void PepsiHydration::modified_expand_volume(grid::GridMember<data::record::Atom>
     grid::detail::GridObj& gref = grid->grid;
     const auto& axes = grid->get_axes();
 
-    double r = 3/settings::grid::width; // fixed radius of 3Å
+    double r = 3/settings::grid::cell_width; // fixed radius of 3Å
 
     // create a box of size [x-r, x+r][y-r, y+r][z-r, z+r] within the bounds
     int x = atom.get_bin_loc().x(), y = atom.get_bin_loc().y(), z = atom.get_bin_loc().z(); 
-    double rvdw = r/settings::grid::width;
+    double rvdw = r/settings::grid::cell_width;
     double rvdw2 = std::pow(rvdw, 2);
 
     int xm = std::max<int>(x - std::ceil(r), 0), xp = std::min<int>(x + std::ceil(r) + 1, axes.x.bins); // xminus and xplus

--- a/source/core/settings/GridSettings.cpp
+++ b/source/core/settings/GridSettings.cpp
@@ -8,14 +8,15 @@ For more information, please refer to the LICENSE file in the project root.
 #include <utility/Exceptions.h>
 
 double settings::grid::water_scaling = 0.01;
-double settings::grid::width = 1;
+double settings::grid::cell_width = 1;
 double settings::grid::scaling = 0.25;
 bool settings::grid::cubic = false;
-double settings::grid::rvol = 2.15;
-double settings::grid::exv_radius = 0.5;
-bool settings::grid::save_exv = false;
+double settings::grid::min_exv_radius = 2.15;
 unsigned int settings::grid::min_bins = 0;
-double settings::grid::surface_thickness = 1;
+
+double settings::grid::exv::surface_thickness = 1;
+double settings::grid::exv::radius = 0.5;
+bool settings::grid::exv::save = false;
 
 namespace settings::grid::detail {
     double min_score = 0.1;
@@ -24,13 +25,13 @@ namespace settings::grid::detail {
 namespace settings::grid::io {
     settings::io::SettingSection grid_settings("Grid", {
         settings::io::create(water_scaling, "water_scaling"),
-        settings::io::create(width, "width"),
+        settings::io::create(cell_width, "width"),
         settings::io::create(scaling, "scaling"),
         settings::io::create(cubic, "cubic"),
-        settings::io::create(rvol, "rvol"),
-        settings::io::create(exv_radius, "exv_radius"),
-        settings::io::create(save_exv, "save_exv"),
-        settings::io::create(surface_thickness, "surface_thickness"),
+        settings::io::create(min_exv_radius, "rvol"),
+        settings::io::create(exv::radius, "exv_radius"),
+        settings::io::create(exv::save, "save_exv"),
+        settings::io::create(exv::surface_thickness, "surface_thickness"),
         settings::io::create(detail::min_score, "detail.min_score"),
     });
 }

--- a/source/core/settings/SettingsValidation.cpp
+++ b/source/core/settings/SettingsValidation.cpp
@@ -44,10 +44,10 @@ void settings::validate_settings() {
 
     switch (settings::hydrate::hydration_strategy) {
         case settings::hydrate::HydrationStrategy::PepsiStrategy:
-            if (settings::grid::width < 3) {
+            if (settings::grid::cell_width < 3) {
                 console::print_warning("Warning: The Pepsi hydration method requires a specific set of grid options. Setting grid width to 3Å and all atomic radii to 3Å.");
-                settings::grid::width = 3;
-                settings::grid::rvol = 3;
+                settings::grid::cell_width = 3;
+                settings::grid::min_exv_radius = 3;
             }
             break;
         default:

--- a/source/crystal/io/CrystalReaderFactory.cpp
+++ b/source/crystal/io/CrystalReaderFactory.cpp
@@ -16,11 +16,11 @@ For more information, please refer to the LICENSE file in the project root.
 
 namespace crystal::factory {
     std::unique_ptr<crystal::io::CrystalReader> CrystalReaderFactory::create(const ::io::ExistingFile& filename) {
-        if (constants::filetypes::unit_cell.validate(filename)) {
+        if (constants::filetypes::unit_cell.check(filename)) {
             return std::make_unique<crystal::io::UnitCellReader>();
-        } else if (constants::filetypes::grid.validate(filename)) {
+        } else if (constants::filetypes::grid.check(filename)) {
             return std::make_unique<crystal::io::GridReader>();
-        } else if (constants::filetypes::structure.validate(filename)) {
+        } else if (constants::filetypes::structure.check(filename)) {
             return std::make_unique<crystal::io::PDBReader>();
         } else {
             throw except::io_error("crystal::io::CrystalReaderFactory::create: Unknown file extension for file \"" + filename + "\"");

--- a/source/em/detail/ImageStackBase.cpp
+++ b/source/em/detail/ImageStackBase.cpp
@@ -159,7 +159,7 @@ void ImageStackBase::read(std::ifstream& istream) {
     double ywidth = axes.y.width();
     double zwidth = axes.z.width();
     double minwidth = std::min({xwidth, ywidth, zwidth})*settings::em::sample_frequency;
-    constants::radius::set_dummy_radius(std::sqrt(2*std::pow(minwidth, 2))/2 + settings::grid::width);
+    constants::radius::set_dummy_radius(std::sqrt(2*std::pow(minwidth, 2))/2 + settings::grid::cell_width);
 }
 
 float& ImageStackBase::index(unsigned int x, unsigned int y, unsigned int layer) {

--- a/tests/em/image_stack.cpp
+++ b/tests/em/image_stack.cpp
@@ -53,7 +53,7 @@ TEST_CASE("ImageStack: test with sphere", "[broken]") {
     header_data->ny = axes.y.bins;
     header_data->nz = axes.z.bins;
 
-    std::vector<em::Image> images(lims.z.span()/settings::grid::width, Matrix<float>(0, 0));
+    std::vector<em::Image> images(lims.z.span()/settings::grid::cell_width, Matrix<float>(0, 0));
     for (unsigned int k = 0; k < images.size(); ++k) {
         Matrix<float> data(axes.x.bins, axes.y.bins);
         for (unsigned int i = 0; i < axes.x.bins; ++i) {

--- a/tests/grid/grid.cpp
+++ b/tests/grid/grid.cpp
@@ -45,7 +45,7 @@ class GridDebug : public grid::Grid {
 };
 
 TEST_CASE("Grid::Grid") {
-    settings::grid::width = 1;
+    settings::grid::cell_width = 1;
 
     SECTION("Limit3D&") {
         Limit3D axes(-10, 10, -10, 10, -10, 10);
@@ -54,8 +54,8 @@ TEST_CASE("Grid::Grid") {
         CHECK(grid.w_members.empty());
         CHECK(grid.get_atoms().empty());
         CHECK(grid.get_volume() == 0);
-        CHECK(grid.get_width() == settings::grid::width);
-        CHECK(grid.get_axes() == Axis3D(axes, settings::grid::width));
+        CHECK(grid.get_width() == settings::grid::cell_width);
+        CHECK(grid.get_axes() == Axis3D(axes, settings::grid::cell_width));
     }
 
     SECTION("vector<Atom>&") {
@@ -65,7 +65,7 @@ TEST_CASE("Grid::Grid") {
         CHECK(grid.w_members.empty());
         CHECK(grid.get_atoms() == atoms);
         CHECK(grid.get_volume() != 0);
-        CHECK(grid.get_width() == settings::grid::width);
+        CHECK(grid.get_width() == settings::grid::cell_width);
     }
 
     SECTION("std::vector<Body>&") {
@@ -75,7 +75,7 @@ TEST_CASE("Grid::Grid") {
         CHECK(grid.w_members.empty());
         CHECK(grid.get_atoms() == bodies[0].get_atoms());
         CHECK(grid.get_volume() != 0);
-        CHECK(grid.get_width() == settings::grid::width);
+        CHECK(grid.get_width() == settings::grid::cell_width);
     }
 
     SECTION("space_saving_constructor") {
@@ -94,12 +94,12 @@ TEST_CASE("Grid::Grid") {
 
         auto func = [] (const Grid& grid) {
             Axis3D axes = grid.get_axes();
-            CHECK(axes.x.min == std::floor( 0 - 5*settings::grid::scaling*0.5 - settings::grid::width));
-            CHECK(axes.y.min == std::floor(-5 - 6*settings::grid::scaling*0.5 - settings::grid::width));
-            CHECK(axes.z.min == std::floor(-7 - 8*settings::grid::scaling*0.5 - settings::grid::width));
-            CHECK(axes.x.max ==  std::ceil(5 + 5*settings::grid::scaling*0.5 + settings::grid::width));
-            CHECK(axes.y.max ==  std::ceil(1 + 6*settings::grid::scaling*0.5 + settings::grid::width));
-            CHECK(axes.z.max ==  std::ceil(1 + 8*settings::grid::scaling*0.5 + settings::grid::width));
+            CHECK(axes.x.min == std::floor( 0 - 5*settings::grid::scaling*0.5 - settings::grid::cell_width));
+            CHECK(axes.y.min == std::floor(-5 - 6*settings::grid::scaling*0.5 - settings::grid::cell_width));
+            CHECK(axes.z.min == std::floor(-7 - 8*settings::grid::scaling*0.5 - settings::grid::cell_width));
+            CHECK(axes.x.max ==  std::ceil(5 + 5*settings::grid::scaling*0.5 + settings::grid::cell_width));
+            CHECK(axes.y.max ==  std::ceil(1 + 6*settings::grid::scaling*0.5 + settings::grid::cell_width));
+            CHECK(axes.z.max ==  std::ceil(1 + 8*settings::grid::scaling*0.5 + settings::grid::cell_width));
 
             // check that we're not using a ton of unnecessary bins
             CHECK(axes.x.bins < 20);
@@ -131,7 +131,7 @@ TEST_CASE("Grid::Grid") {
 
 TEST_CASE("generation") {
     Limit3D axes(-10, 10, -10, 10, -10, 10);
-    settings::grid::width = 1;
+    settings::grid::cell_width = 1;
     Grid grid(axes);
 
     vector<Atom> a = {Atom({0, 0, 0}, 0,  constants::atom_t::C, "", 0)};
@@ -158,7 +158,7 @@ TEST_CASE("GridMember") {
 
 TEST_CASE("Grid::bounding_box") {
     Limit3D axes(-10, 10, -10, 10, -10, 10);
-    settings::grid::width = 1;
+    settings::grid::cell_width = 1;
     GridDebug grid(axes);
 
     SECTION("simple") {
@@ -192,7 +192,7 @@ TEST_CASE("Grid::bounding_box") {
 TEST_CASE("Grid::get_volume") {
     SECTION("simple") {
         Limit3D lims(-10, 10, -10, 10, -10, 10);
-        settings::grid::width = 1e-1;
+        settings::grid::cell_width = 1e-1;
         Grid grid(lims);
 
         std::vector<Atom> a = {Atom({0, 0, 0}, 0,  constants::atom_t::C, "", 0)};
@@ -213,12 +213,12 @@ TEST_CASE("Grid::get_volume") {
         }
 
         REQUIRE(count != 0);
-        CHECK(grid.get_volume() == count*std::pow(settings::grid::width, 3));
+        CHECK(grid.get_volume() == count*std::pow(settings::grid::cell_width, 3));
     }
 
     SECTION("multiple atoms") {
         Limit3D axes(-10, 10, -10, 10, -10, 10);
-        settings::grid::width = 1;
+        settings::grid::cell_width = 1;
         GridDebug grid(axes);
         grid.set_atomic_radius(1);
 
@@ -230,7 +230,7 @@ TEST_CASE("Grid::get_volume") {
         REQUIRE(grid.get_volume_without_expanding() == 1); // atoms are added as point-particles, and only occupy one unit of space.
 
         SECTION("") {
-            settings::grid::rvol = 1;
+            settings::grid::min_exv_radius = 1;
             REQUIRE(grid.get_volume() == 7); // the radius is 1, so expanding the volume in a sphere results in one unit of volume added along each coordinate axis
 
             grid.add(Atom({0, 0, -1}, 0,  constants::atom_t::C, "", 0));
@@ -238,7 +238,7 @@ TEST_CASE("Grid::get_volume") {
         }
 
         SECTION("") {
-            settings::grid::rvol = 2;
+            settings::grid::min_exv_radius = 2;
             grid.expand_volume();
             REQUIRE(grid.get_volume() == 33);
         }
@@ -247,31 +247,31 @@ TEST_CASE("Grid::get_volume") {
 
 TEST_CASE("Grid::width") {
     // check that the grid width is actually used
-    settings::grid::width = GENERATE(0.25, 0.5, 1, 2);
+    settings::grid::cell_width = GENERATE(0.25, 0.5, 1, 2);
 
     Limit3D lims(-10, 10, -10, 10, -10, 10);
     Grid grid(lims);
 
     auto axes = grid.get_axes();
     for (unsigned int i = 0; i < axes.x.bins-1; ++i) {
-        CHECK(grid.to_xyz(i, 0, 0).distance(grid.to_xyz(i+1, 0, 0)) == settings::grid::width);
-        CHECK(grid.to_xyz(0, i, 0).distance(grid.to_xyz(0, i+1, 0)) == settings::grid::width);
-        CHECK(grid.to_xyz(0, 0, i).distance(grid.to_xyz(0, 0, i+1)) == settings::grid::width);
+        CHECK(grid.to_xyz(i, 0, 0).distance(grid.to_xyz(i+1, 0, 0)) == settings::grid::cell_width);
+        CHECK(grid.to_xyz(0, i, 0).distance(grid.to_xyz(0, i+1, 0)) == settings::grid::cell_width);
+        CHECK(grid.to_xyz(0, 0, i).distance(grid.to_xyz(0, 0, i+1)) == settings::grid::cell_width);
     }
 
     auto center = grid.get_center();
     CHECK(grid.to_xyz(center) == Vector3<double>{0, 0, 0});
-    CHECK(grid.to_xyz(center+Vector3<double>{1, 0, 0}) == Vector3<double>{settings::grid::width, 0, 0});
-    CHECK(grid.to_xyz(center+Vector3<double>{0, 1, 0}) == Vector3<double>{0, settings::grid::width, 0});
-    CHECK(grid.to_xyz(center+Vector3<double>{0, 0, 1}) == Vector3<double>{0, 0, settings::grid::width});
+    CHECK(grid.to_xyz(center+Vector3<double>{1, 0, 0}) == Vector3<double>{settings::grid::cell_width, 0, 0});
+    CHECK(grid.to_xyz(center+Vector3<double>{0, 1, 0}) == Vector3<double>{0, settings::grid::cell_width, 0});
+    CHECK(grid.to_xyz(center+Vector3<double>{0, 0, 1}) == Vector3<double>{0, 0, settings::grid::cell_width});
 }
 
 TEST_CASE("Grid::expand_volume") {
     SECTION("shape test") {
         settings::molecule::use_effective_charge = false;
         Limit3D lims(-10, 10, -10, 10, -10, 10);
-        settings::grid::width = 1;
-        settings::grid::rvol = 2.15;
+        settings::grid::cell_width = 1;
+        settings::grid::min_exv_radius = 2.15;
         Grid grid(lims);
         constants::radius::set_dummy_radius(3+1e-6);
 
@@ -301,7 +301,7 @@ TEST_CASE("Grid::expand_volume") {
         settings::grid::min_bins = 30;
 
         SECTION("five atoms") {
-            settings::grid::rvol = 3;
+            settings::grid::min_exv_radius = 3;
             std::vector<Atom> atoms = {
                 Atom({0, 0, 0}, 1, constants::atom_t::C, "C", 1),
                 Atom({-2, 0, 0}, 1, constants::atom_t::C, "C", 1),
@@ -326,7 +326,7 @@ TEST_CASE("Grid::hydrate") {
     // check that all the expected hydration sites are found
     SECTION("correct placement " + std::to_string(static_cast<int>(settings::hydrate::hydration_strategy))) {
         Limit3D axes(-10, 10, -10, 10, -10, 10);
-        settings::grid::width = 1;
+        settings::grid::cell_width = 1;
         auto grid = std::make_unique<GridDebug>(axes);
         grid->set_atomic_radius(3);
         grid->set_hydration_radius(3);
@@ -414,7 +414,7 @@ TEST_CASE("Grid: using different widths") {
     settings::general::verbose = false;
     auto test_width_basics = [] (settings::hydrate::HydrationStrategy strategy) {
         settings::hydrate::hydration_strategy = strategy;
-        settings::grid::width = 0.1;
+        settings::grid::cell_width = 0.1;
         vector<Atom> a = {Atom({0, 0, 0}, 0,  constants::atom_t::C, "LYS", 0)};
         data::Molecule protein(a);
         {
@@ -453,7 +453,7 @@ TEST_CASE("Grid: using different widths") {
 
     auto test_width_bounds = [] (settings::hydrate::HydrationStrategy strategy) {
         settings::hydrate::hydration_strategy = strategy;
-        settings::grid::width = 0.1;
+        settings::grid::cell_width = 0.1;
         Limit3D axes(-10, 10, -10, 10, -10, 10);
         GridDebug grid(axes);
         grid.set_atomic_radius(3);
@@ -500,7 +500,7 @@ TEST_CASE("Grid: using different widths") {
 
 TEST_CASE("Grid: add and remove") {
     Limit3D axes(-10, 10, -10, 10, -10, 10);
-    settings::grid::width = 1;
+    settings::grid::cell_width = 1;
     GridDebug grid(axes);
     grid.set_atomic_radius(3);
     grid.set_hydration_radius(3);
@@ -617,7 +617,7 @@ TEST_CASE("Grid: add and remove") {
 
 TEST_CASE("Grid: correct_volume") {
     Limit3D axes(-10, 10, -10, 10, -10, 10);
-    settings::grid::width = 1;
+    settings::grid::cell_width = 1;
     GridDebug grid(axes);
     grid.set_atomic_radius(10);     // heavy overlap
     grid.set_hydration_radius(10);
@@ -659,7 +659,7 @@ TEST_CASE("Grid::find_free_locs") {
     settings::general::verbose = false;
     auto test_func = [] (settings::hydrate::HydrationStrategy ch) {
         settings::hydrate::hydration_strategy = ch;
-        settings::grid::width = 1;
+        settings::grid::cell_width = 1;
 
         Limit3D axes(-10, 10, -10, 10, -10, 10);
         auto grid = std::make_unique<GridDebug>(axes);
@@ -706,7 +706,7 @@ TEST_CASE("Grid::deflate_volume") {
     settings::grid::min_bins = 0;
 
     Limit3D axes(-10, 10, -10, 10, -10, 10);
-    settings::grid::width = 1;
+    settings::grid::cell_width = 1;
     auto grid = std::make_unique<GridDebug>(axes);
     grid->set_atomic_radius(3);
     grid->set_hydration_radius(3);
@@ -736,7 +736,7 @@ TEST_CASE("Grid::deflate_volume") {
 
 TEST_CASE("Grid: cubic_grid") {
     settings::grid::cubic = true;
-    settings::grid::width = GENERATE(0.1, 0.5, 1);
+    settings::grid::cell_width = GENERATE(0.1, 0.5, 1);
 
     SECTION("largest x") {
         Limit3D axes(-10, 10, -1, 1, -1, 1);

--- a/tests/grid/grid_surface_detection.cpp
+++ b/tests/grid/grid_surface_detection.cpp
@@ -41,7 +41,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     settings::molecule::center = true;
 
     SECTION("Single with radius") {
-        settings::grid::rvol = std::sqrt(3)+1e-3;
+        settings::grid::min_exv_radius = std::sqrt(3)+1e-3;
 
         Molecule protein({Atom({0, 0, 0}, 1, constants::atom_t::C, "C", 1)});
         GridDebug::generate_debug_grid(protein);
@@ -52,7 +52,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("Two atoms with radius") {
-        settings::grid::rvol = std::sqrt(2)+1e-3;
+        settings::grid::min_exv_radius = std::sqrt(2)+1e-3;
         std::vector<Atom> atoms = {
             Atom({0, 0, 0}, 1, constants::atom_t::C, "C", 1),
             Atom({1, 0, 0}, 1, constants::atom_t::C, "C", 1)
@@ -67,7 +67,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("2x2x2 interior simple") {
-        settings::grid::rvol = 2;
+        settings::grid::min_exv_radius = 2;
         std::vector<Atom> atoms;
         for (double x = 0; x <= 1; x+=1) {
             for (double y = 0; y <= 1; y+=1) {
@@ -87,7 +87,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("2x2x2 interior advanced") {
-        settings::grid::rvol = std::sqrt(2)+1e-3;
+        settings::grid::min_exv_radius = std::sqrt(2)+1e-3;
         std::vector<Atom> atoms;
         for (double x = 0; x <= 1; x+=1) {
             for (double y = 0; y <= 1; y+=1) {
@@ -107,7 +107,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("3x3x3") {
-        settings::grid::rvol = 2;
+        settings::grid::min_exv_radius = 2;
         std::vector<Atom> atoms;
         for (double x = -1; x <= 1; x+=1) {
             for (double y = -1; y <= 1; y+=1) {
@@ -127,7 +127,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("larger radius, single") {
-        settings::grid::rvol = 2;
+        settings::grid::min_exv_radius = 2;
         std::vector<Atom> atoms = {Atom({0, 0, 0}, 1, constants::atom_t::C, "C", 1)};
 
         Molecule protein(atoms);
@@ -139,7 +139,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("much larger radius, single") {
-        settings::grid::rvol = 3;
+        settings::grid::min_exv_radius = 3;
         std::vector<Atom> atoms = {Atom({0, 0, 0}, 1, constants::atom_t::C, "C", 1)};
 
         Molecule protein(atoms);
@@ -151,7 +151,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("larger radius, cube") {
-        settings::grid::rvol = 2;
+        settings::grid::min_exv_radius = 2;
         std::vector<Atom> atoms;
         for (double x = -1; x <= 1; x+=1) {
             for (double y = -1; y <= 1; y+=1) {
@@ -171,7 +171,7 @@ TEST_CASE("GridSurfaceDetection::detect_atoms") {
     }
 
     SECTION("larger radius, larger cube") {
-        settings::grid::rvol = 2;
+        settings::grid::min_exv_radius = 2;
         std::vector<Atom> atoms = {
             Atom({-2, 0, 0}, 1, constants::atom_t::C, "C", 1),
             Atom({2, 0, 0}, 1, constants::atom_t::C, "C", 1),
@@ -233,10 +233,10 @@ TEST_CASE("GridSurfaceDetection: thickness") {
     settings::molecule::use_effective_charge = false;
     settings::molecule::implicit_hydrogens = false;
     settings::molecule::center = true;
-    settings::grid::surface_thickness = 2;
+    settings::grid::exv::surface_thickness = 2;
 
     SECTION("2x2x2 interior simple") {
-        settings::grid::rvol = 2.5;
+        settings::grid::min_exv_radius = 2.5;
         std::vector<Atom> atoms;
         for (double x = 0; x <= 1; x+=1) {
             for (double y = 0; y <= 1; y+=1) {
@@ -256,7 +256,7 @@ TEST_CASE("GridSurfaceDetection: thickness") {
     }
 
     SECTION("3x3x3") {
-        settings::grid::rvol = 3;
+        settings::grid::min_exv_radius = 3;
         std::vector<Atom> atoms;
         for (double x = -1; x <= 1; x+=1) {
             for (double y = -1; y <= 1; y+=1) {
@@ -276,7 +276,7 @@ TEST_CASE("GridSurfaceDetection: thickness") {
     }
 
     SECTION("much larger radius, single") {
-        settings::grid::rvol = 4;
+        settings::grid::min_exv_radius = 4;
         std::vector<Atom> atoms = {Atom({0, 0, 0}, 1, constants::atom_t::C, "C", 1)};
 
         Molecule protein(atoms);
@@ -288,7 +288,7 @@ TEST_CASE("GridSurfaceDetection: thickness") {
     }
 
     SECTION("larger radius, larger cube") {
-        settings::grid::rvol = 3;
+        settings::grid::min_exv_radius = 3;
         std::vector<Atom> atoms = {
             Atom({0, 0, 0}, 1, constants::atom_t::C, "C", 1),
             Atom({-2, 0, 0}, 1, constants::atom_t::C, "C", 1),

--- a/tests/hist/composite_distance_histogram_ff_grid.cpp
+++ b/tests/hist/composite_distance_histogram_ff_grid.cpp
@@ -28,8 +28,8 @@ TEST_CASE("CompositeDistanceHistogramFFGrid::volumes", "[manual]") {
     std::vector<double> volumes;
     std::vector<double> rxs;
     for (double rx = 0.1; rx < 1; rx += 0.1) {
-        settings::grid::width = rx;
-        settings::grid::exv_radius = rx;
+        settings::grid::cell_width = rx;
+        settings::grid::exv::radius = rx;
         protein.clear_grid();
         volumes.push_back(protein.get_volume_grid());
         rxs.push_back(rx);
@@ -57,7 +57,7 @@ auto calc_scat = [] (double k) {
     const auto& q_axis = constants::axes::q_vals;
     auto ff_C = form_factor::storage::atomic::get_form_factor(form_factor::form_factor_t::C);
 
-    auto V = std::pow(2*settings::grid::exv_radius, 3);
+    auto V = std::pow(2*settings::grid::exv::radius, 3);
     form_factor::FormFactor ffx = form_factor::ExvFormFactor(V);
     auto d = SimpleCube::d_exact;
 
@@ -131,7 +131,7 @@ auto calc_scat_water = [] () {
     auto ff_C = form_factor::storage::atomic::get_form_factor(form_factor::form_factor_t::C);
     auto ff_O = form_factor::storage::atomic::get_form_factor(static_cast<form_factor::form_factor_t>(form_factor::water_bin));
 
-    auto V = std::pow(2*settings::grid::exv_radius, 3);
+    auto V = std::pow(2*settings::grid::exv::radius, 3);
     form_factor::FormFactor ffx = form_factor::ExvFormFactor(V);
     auto d = SimpleCube::d_exact;
 
@@ -160,9 +160,9 @@ TEST_CASE("HistogramManagerMTFFGrid::debye_transform") {
     settings::molecule::implicit_hydrogens = false;
     settings::molecule::center = true;
     settings::hist::weighted_bins = true;
-    settings::grid::width = 1;
-    settings::grid::exv_radius = 0.5;
-    settings::grid::rvol = 0;
+    settings::grid::min_exv_radius = 1;
+    settings::grid::exv::radius = 0.5;
+    settings::grid::min_exv_radius = 0;
 
     std::vector<Atom> atoms = SimpleCube::get_atoms();
     atoms.push_back(Atom(Vector3<double>(0, 0, 0), 1, constants::atom_t::C, "C", 1));
@@ -205,9 +205,9 @@ TEST_CASE("HistogramManagerMTFFGridSurface: surface_scaling") {
     settings::molecule::implicit_hydrogens = false;
     settings::molecule::center = true;
     settings::hist::weighted_bins = true;
-    settings::grid::width = 1;
-    settings::grid::exv_radius = 0.5;
-    settings::grid::rvol = 0;
+    settings::grid::cell_width = 1;
+    settings::grid::exv::radius = 0.5;
+    settings::grid::min_exv_radius = 0;
 
     std::vector<Atom> atoms = SimpleCube::get_atoms();
     atoms.push_back(Atom(Vector3<double>(0, 0, 0), 1, constants::atom_t::C, "C", 1));

--- a/tests/hist/histogram_manager_mt_ff_grid.cpp
+++ b/tests/hist/histogram_manager_mt_ff_grid.cpp
@@ -110,10 +110,10 @@ auto test = [] (const Molecule& protein, std::function<std::unique_ptr<IComposit
 TEST_CASE("HistogramManagerMTFFGrid::calculate", "[files]") {
     settings::molecule::use_effective_charge = false;
     SECTION("simple") {
-        settings::grid::width = GENERATE(0.2, 0.5, 1, 2);
-        settings::grid::exv_radius = settings::grid::width;
+        settings::grid::cell_width = GENERATE(0.2, 0.5, 1, 2);
+        settings::grid::exv::radius = settings::grid::cell_width;
 
-        SECTION(std::string("width = ") + std::to_string(settings::grid::width)) {
+        SECTION(std::string("width = ") + std::to_string(settings::grid::cell_width)) {
             Atom a1(0, "C", "", "LYS", 'A', 1, "", {0, 0, 0}, 1, 0, constants::atom_t::dummy, "");
             Molecule protein({a1});
             test(protein, [](const Molecule& protein) {return hist::HistogramManagerMTFFGrid(&protein).calculate_all();});
@@ -122,8 +122,8 @@ TEST_CASE("HistogramManagerMTFFGrid::calculate", "[files]") {
 
     SECTION("actual data") {
         settings::general::verbose = false;
-        settings::grid::width = 1;
-        settings::grid::exv_radius = 1;
+        settings::grid::cell_width = 1;
+        settings::grid::exv::radius = 1;
         Molecule protein("tests/files/LAR1-2.pdb");
         protein.clear_hydration();
         test(protein, [](const Molecule& protein) {return hist::HistogramManagerMTFFGrid(&protein).calculate_all();});
@@ -137,11 +137,11 @@ TEST_CASE("HistogramManagerMTFFGridSurface::calculate", "[files]") {
     settings::general::verbose = false;
 
     SECTION("simple") {
-        settings::grid::width = GENERATE(0.2, 0.5, 1, 2);
-        settings::grid::exv_radius = settings::grid::width;
-        settings::grid::surface_thickness = settings::grid::width;
+        settings::grid::cell_width = GENERATE(0.2, 0.5, 1, 2);
+        settings::grid::exv::radius = settings::grid::cell_width;
+        settings::grid::exv::surface_thickness = settings::grid::cell_width;
 
-        SECTION(std::string("width = ") + std::to_string(settings::grid::width)) {
+        SECTION(std::string("width = ") + std::to_string(settings::grid::cell_width)) {
             Atom a1(0, "C", "", "LYS", 'A', 1, "", {0, 0, 0}, 1, 0, constants::atom_t::dummy, "");
             Molecule protein({a1});
             test(protein, [](const Molecule& protein) {return hist::HistogramManagerMTFFGridSurface(&protein).calculate_all();});
@@ -150,9 +150,9 @@ TEST_CASE("HistogramManagerMTFFGridSurface::calculate", "[files]") {
 
     SECTION("actual data") {
         settings::general::verbose = false;
-        settings::grid::width = 1;
-        settings::grid::exv_radius = 1;
-        settings::grid::surface_thickness = 1;
+        settings::grid::cell_width = 1;
+        settings::grid::exv::radius = 1;
+        settings::grid::exv::surface_thickness = 1;
         Molecule protein("tests/files/LAR1-2.pdb");
         protein.clear_hydration();
         test(protein, [](const Molecule& protein) {return hist::HistogramManagerMTFFGridSurface(&protein).calculate_all();});
@@ -254,7 +254,7 @@ TEST_CASE("HistogramManagerMTFFGrid: weighted_bins", "[files]") {
     }
 
     SECTION("simple, all") {
-        settings::grid::rvol = 0;
+        settings::grid::min_exv_radius = 0;
         std::vector<Atom> atoms = SimpleCube::get_atoms();
         atoms.push_back(Atom(Vector3<double>(0, 0, 0), 1, constants::atom_t::C, "C", 1));
         std::for_each(atoms.begin(), atoms.end(), [](Atom& a) {a.set_effective_charge(1);});

--- a/tests/hist/weighted_distribution.cpp
+++ b/tests/hist/weighted_distribution.cpp
@@ -294,14 +294,14 @@ TEST_CASE("6lyz_exv", "[manual]") {
     settings::molecule::center = false;
     settings::axes::qmin = 5e-2;
     settings::axes::qmax = 1;
-    settings::grid::exv_radius = 1.5;
-    settings::grid::rvol = 2;
+    settings::grid::exv::radius = 1.5;
+    settings::grid::min_exv_radius = 2;
     constants::radius::set_dummy_radius(2);
 
     data::Molecule protein("tests/files/6lyz_exv.pdb");
     for (auto& b : protein.get_bodies()) {for (auto& a : b.get_atoms()){a.element = constants::atom_t::dummy;}}
     auto Iq =  static_cast<hist::CompositeDistanceHistogramFFGrid*>(hist::HistogramManagerMTFFGrid(&protein).calculate_all().get())->get_profile_xx().as_dataset();
-    auto Iqexact = exact(protein, settings::grid::exv_radius).as_dataset();
+    auto Iqexact = exact(protein, settings::grid::exv::radius).as_dataset();
 
     Iq.normalize();
     Iqexact.normalize();


### PR DESCRIPTION
Updated names of Grid settings.

Fixed bug where no spherical expansion of atoms would occur when grid::settings::rvol < vdw of the atom.  