### PR TITLE
Support RNA calculations

### DIFF
--- a/source/core/io/detail/CIFReader.cpp
+++ b/source/core/io/detail/CIFReader.cpp
@@ -346,17 +346,21 @@ CIFSection extract_section(std::string line, std::ifstream& input) {
     while(input.peek() != '_' && getline(input, line) && !line.starts_with("loop_")) {
         if (line.starts_with('#')) {continue;}
         auto values = utility::split(line, " ");
-
+        
         int concatenated = 0;
         for (size_t i = 0; i < values.size(); i++) {
-            if (values[i].starts_with('"') && !values[i].ends_with('"')) {
-                if (i < values.size() && values[i+1].ends_with('"')) {
-                    values[i] = values[i].substr(1) + " " + values[i+1].substr(0, values[i+1].size()-1);
+            if (values[i].starts_with('"')) {
+                if (values[i].ends_with('"')) {
+                    values[i] = values[i].substr(1, values[i].size()-2);
                 } else {
-                    throw except::io_error("CIFReader::read: Unterminated quote in data section: \n\"" + line + "\"");
+                    if (i < values.size() && values[i+1].ends_with('"')) {
+                        values[i] = values[i].substr(1) + " " + values[i+1].substr(0, values[i+1].size()-1);
+                    } else {
+                        throw except::io_error("CIFReader::read: Unterminated quote in data section: \n\"" + line + "\"");
+                    }
+                    ++concatenated;
+                    continue;
                 }
-                ++concatenated;
-                continue;
             }
             values[i-concatenated] = values[i];
         }

--- a/source/core/residue/ResidueStorage.cpp
+++ b/source/core/residue/ResidueStorage.cpp
@@ -108,7 +108,7 @@ void ResidueStorage::initialize() {
 
 bool ResidueStorage::update_or_download_residue(const std::string& name) {
     std::string path = settings::general::residue_folder;
-    std::regex regex("[A-Z0-9]{2,3}");
+    std::regex regex("[A-Z0-9]{1,3}");
 
     if (std::regex_match(name, regex)) {
         // check if the file already exists. if not, download it.


### PR DESCRIPTION
Previously, residues were required to have at least 2 letters, which unintentionally made it impossible to calculate the scattering from the common DNA bases (G, C, ...). 

A minor issue with quoted atomic names were also fixed. 