### PR TITLE
Expanded atomic support

### DIFF
--- a/include/core/constants/Constants.h
+++ b/include/core/constants/Constants.h
@@ -116,7 +116,11 @@ namespace ausaxs::constants {
      * @brief Valence atoms
      */
     namespace valence {
-        // get the valence of an atom
+        /**
+         * @brief Get the valence of an atom.
+         *        Note that this is *not* the number of valence electrons, but the typical number of bonds the atom can form.
+         *        This information is primarily used to determine the number of hydrogens attached to an atom, as these are often not present in the PDB file.
+         */
         unsigned int get_valence(atom_t atom);
     }
 

--- a/include/core/constants/ConstantsFwd.h
+++ b/include/core/constants/ConstantsFwd.h
@@ -3,7 +3,8 @@
 namespace ausaxs::constants {
     // Atom enum for a consistent way to denote the type of an atom. Example values: C, H, O, dummy
     enum class atom_t {
-        H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn, I, W, 
+        H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn, Ga, Ge, As, Se, 
+        I, W, 
         M,      // This fake element is for compatibility with the GROMACS tip4p water model.
         dummy,  // Fake element for dummy atoms with variable properties. 
         unknown

--- a/include/core/constants/ConstantsFwd.h
+++ b/include/core/constants/ConstantsFwd.h
@@ -3,8 +3,12 @@
 namespace ausaxs::constants {
     // Atom enum for a consistent way to denote the type of an atom. Example values: C, H, O, dummy
     enum class atom_t {
-        H, He, Li, Be, B, C, N, O, F, Ne, Na, Mg, Al, Si, P, S, Cl, Ar, K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn, Ga, Ge, As, Se, 
-        I, W, 
+        H, He, 
+        Li, Be, B, C, N, O, F, Ne, 
+        Na, Mg, Al, Si, P, S, Cl, Ar, 
+        K, Ca, Sc, Ti, V, Cr, Mn, Fe, Co, Ni, Cu, Zn, Ga, Ge, As, Se, Br, Kr,
+        Rb, Sr, Y, Zr, Nb, Mo, Tc, Ru, Rh, Pd, Ag, Cd, In, Sn, Sb, Te, I, Xe,
+        W, 
         M,      // This fake element is for compatibility with the GROMACS tip4p water model.
         dummy,  // Fake element for dummy atoms with variable properties. 
         unknown

--- a/include/core/constants/vdwTable.h
+++ b/include/core/constants/vdwTable.h
@@ -2,7 +2,7 @@
 
 namespace ausaxs::constants::radius::vdw {
     // Rowland 1996, crystallographic
-    constexpr double H = 1.1;
+    constexpr double H  = 1.1;
 
     // wikipedia, likely also crystallographic
     constexpr double He = 1.4;
@@ -12,23 +12,25 @@ namespace ausaxs::constants::radius::vdw {
     // Batsanov, 2001, equilibrium values
     constexpr double Li = 2.63;
     constexpr double Be = 2.23;
-    constexpr double B = 2.05;
-    constexpr double C = 1.96;
-    constexpr double N = 1.79;
-    constexpr double O = 1.71;
-    constexpr double F = 1.65;
+    constexpr double B  = 2.05;
+    constexpr double C  = 1.96;
+    constexpr double N  = 1.79;
+    constexpr double O  = 1.71;
+    constexpr double F  = 1.65;
+
     constexpr double Na = 2.77;
     constexpr double Mg = 2.42;
     constexpr double Al = 2.40;
     constexpr double Si = 2.26;
-    constexpr double P = 2.14;
-    constexpr double S = 2.06;
+    constexpr double P  = 2.14;
+    constexpr double S  = 2.06;
     constexpr double Cl = 2.05;
-    constexpr double K = 3.02;
+
+    constexpr double K  = 3.02;
     constexpr double Ca = 2.78;
     constexpr double Sc = 2.62;
     constexpr double Ti = 2.44;
-    constexpr double V = 2.27;
+    constexpr double V  = 2.27;
     constexpr double Cr = 2.23;
     constexpr double Mn = 2.25;
     constexpr double Fe = 2.27;
@@ -40,6 +42,25 @@ namespace ausaxs::constants::radius::vdw {
     constexpr double Ge = 2.32;
     constexpr double As = 2.25;
     constexpr double Se = 2.18;
-    constexpr double I = 2.22;
-    constexpr double W = 2.36;
+    constexpr double Br = 2.10;
+
+    constexpr double Rb = 3.15;
+    constexpr double Sr = 2.94;
+    constexpr double Y  = 2.71;
+    constexpr double Zr = 2.57;
+    constexpr double Nb = 2.46;
+    constexpr double Mo = 2.39;
+    constexpr double Tc = 2.37;
+    constexpr double Ru = 2.37;
+    constexpr double Rh = 2.32;
+    constexpr double Pd = 2.35;
+    constexpr double Ag = 2.37;
+    constexpr double Cd = 2.37;
+    constexpr double In = 2.53;
+    constexpr double Sn = 2.46;
+    constexpr double Sb = 2.41;
+    constexpr double Te = 2.36;
+    constexpr double I  = 2.22;
+
+    constexpr double W  = 2.36;
 }

--- a/include/core/constants/vdwTable.h
+++ b/include/core/constants/vdwTable.h
@@ -36,6 +36,10 @@ namespace ausaxs::constants::radius::vdw {
     constexpr double Ni = 2.23;
     constexpr double Cu = 2.27;
     constexpr double Zn = 2.24;
+    constexpr double Ga = 2.41;
+    constexpr double Ge = 2.32;
+    constexpr double As = 2.25;
+    constexpr double Se = 2.18;
     constexpr double I = 2.22;
     constexpr double W = 2.36;
 }

--- a/source/core/constants/Constants.cpp
+++ b/source/core/constants/Constants.cpp
@@ -45,8 +45,8 @@ namespace ausaxs::constants {
         {"H", atom_t::H},   {"He", atom_t::He}, {"Li", atom_t::Li}, {"Be", atom_t::Be}, {"B", atom_t::B},   {"C", atom_t::C},   {"N", atom_t::N}, {"O", atom_t::O}, 
         {"F", atom_t::F},   {"Ne", atom_t::Ne}, {"Na", atom_t::Na}, {"Mg", atom_t::Mg}, {"Al", atom_t::Al}, {"Si", atom_t::Si}, {"P", atom_t::P}, {"S", atom_t::S}, 
         {"Cl", atom_t::Cl}, {"Ar", atom_t::Ar}, {"K", atom_t::K},   {"Ca", atom_t::Ca}, {"Sc", atom_t::Sc}, {"Ti", atom_t::Ti}, {"V", atom_t::V}, {"Cr", atom_t::Cr}, 
-        {"Mn", atom_t::Mn}, {"Fe", atom_t::Fe}, {"Co", atom_t::Co}, {"Ni", atom_t::Ni}, {"Cu", atom_t::Cu}, {"Zn", atom_t::Zn}, {"I", atom_t::I}, {"W", atom_t::W}, 
-        {"M", atom_t::M}
+        {"Mn", atom_t::Mn}, {"Fe", atom_t::Fe}, {"Co", atom_t::Co}, {"Ni", atom_t::Ni}, {"Cu", atom_t::Cu}, {"Zn", atom_t::Zn}, {"Ga", atom_t::Ga}, {"Ge", atom_t::Ge}, 
+        {"As", atom_t::As}, {"Se", atom_t::Se}, {"I", atom_t::I},   {"W", atom_t::W},   {"M", atom_t::M}
     };
 
     residue::ResidueStorage hydrogen_atoms::residues;
@@ -98,29 +98,29 @@ constants::atomic_group_t constants::symbols::get_atomic_group(constants::atom_t
 
 unsigned int constants::charge::nuclear::get_charge(atom_t atom) {
     switch(atom) {
-        case atom_t::H: return 1;
+        case atom_t::H:  return 1;
         case atom_t::He: return 2;
         case atom_t::Li: return 3;
         case atom_t::Be: return 4;
-        case atom_t::B: return 5;
-        case atom_t::C: return 6;
-        case atom_t::N: return 7;
-        case atom_t::O: return 8;
-        case atom_t::F: return 9;
+        case atom_t::B:  return 5;
+        case atom_t::C:  return 6;
+        case atom_t::N:  return 7;
+        case atom_t::O:  return 8;
+        case atom_t::F:  return 9;
         case atom_t::Ne: return 10;
         case atom_t::Na: return 11;
         case atom_t::Mg: return 12;
         case atom_t::Al: return 13;
         case atom_t::Si: return 14;
-        case atom_t::P: return 15;
-        case atom_t::S: return 16;
+        case atom_t::P:  return 15;
+        case atom_t::S:  return 16;
         case atom_t::Cl: return 17;
         case atom_t::Ar: return 18;
-        case atom_t::K: return 19;
+        case atom_t::K:  return 19;
         case atom_t::Ca: return 20;
         case atom_t::Sc: return 21;
         case atom_t::Ti: return 22;
-        case atom_t::V: return 23;
+        case atom_t::V:  return 23;
         case atom_t::Cr: return 24;
         case atom_t::Mn: return 25;
         case atom_t::Fe: return 26;
@@ -128,9 +128,13 @@ unsigned int constants::charge::nuclear::get_charge(atom_t atom) {
         case atom_t::Ni: return 28;
         case atom_t::Cu: return 29;
         case atom_t::Zn: return 30;
-        case atom_t::I: return 53;
-        case atom_t::W: return 74;
-        case atom_t::M: return 0;
+        case atom_t::Ga: return 31;
+        case atom_t::Ge: return 32;
+        case atom_t::As: return 33;
+        case atom_t::Se: return 34;
+        case atom_t::I:  return 53;
+        case atom_t::W:  return 74;
+        case atom_t::M:  return 0;
         case atom_t::dummy: return 1;
         default: throw std::runtime_error("constants::charge::nuclear::get_charge: Unknown atom type \"" + constants::symbols::to_string(atom) + "\"");
     }
@@ -157,6 +161,7 @@ unsigned int constants::valence::get_valence(atom_t atom) {
         case atom_t::P:  return 1;
         case atom_t::Cl: return 1;
         case atom_t::Fe: return 4;
+        case atom_t::Se: return 2;
         case atom_t::M:  return 0;
         default: throw std::runtime_error("constants::valence::get_valence: Unknown atom type \"" + constants::symbols::to_string(atom) + "\"");
     }
@@ -164,29 +169,29 @@ unsigned int constants::valence::get_valence(atom_t atom) {
 
 double constants::radius::get_vdw_radius(atom_t atom) {
     switch(atom) {
-        case atom_t::H: return vdw::H;
+        case atom_t::H:  return vdw::H;
         case atom_t::He: return vdw::He;
         case atom_t::Ne: return vdw::Ne;
         case atom_t::Ar: return vdw::Ar;
         case atom_t::Li: return vdw::Li;
         case atom_t::Be: return vdw::Be;
-        case atom_t::B: return vdw::B;
-        case atom_t::C: return vdw::C;
-        case atom_t::N: return vdw::N;
-        case atom_t::O: return vdw::O;
-        case atom_t::F: return vdw::F;
+        case atom_t::B:  return vdw::B;
+        case atom_t::C:  return vdw::C;
+        case atom_t::N:  return vdw::N;
+        case atom_t::O:  return vdw::O;
+        case atom_t::F:  return vdw::F;
         case atom_t::Na: return vdw::Na;
         case atom_t::Mg: return vdw::Mg;
         case atom_t::Al: return vdw::Al;
         case atom_t::Si: return vdw::Si;
-        case atom_t::P: return vdw::P;
-        case atom_t::S: return vdw::S;
+        case atom_t::P:  return vdw::P;
+        case atom_t::S:  return vdw::S;
         case atom_t::Cl: return vdw::Cl;
-        case atom_t::K: return vdw::K;
+        case atom_t::K:  return vdw::K;
         case atom_t::Ca: return vdw::Ca;
         case atom_t::Sc: return vdw::Sc;
         case atom_t::Ti: return vdw::Ti;
-        case atom_t::V: return vdw::V;
+        case atom_t::V:  return vdw::V;
         case atom_t::Cr: return vdw::Cr;
         case atom_t::Mn: return vdw::Mn;
         case atom_t::Fe: return vdw::Fe;
@@ -194,8 +199,12 @@ double constants::radius::get_vdw_radius(atom_t atom) {
         case atom_t::Ni: return vdw::Ni;
         case atom_t::Cu: return vdw::Cu;
         case atom_t::Zn: return vdw::Zn;
-        case atom_t::I: return vdw::I;
-        case atom_t::W: return vdw::W;
+        case atom_t::Ga: return vdw::Ga;
+        case atom_t::Ge: return vdw::Ge;
+        case atom_t::As: return vdw::As;
+        case atom_t::Se: return vdw::Se;
+        case atom_t::I:  return vdw::I;
+        case atom_t::W:  return vdw::W;
 
         // fake elements
         case atom_t::M: return 0;
@@ -206,29 +215,29 @@ double constants::radius::get_vdw_radius(atom_t atom) {
 
 std::string ausaxs::constants::symbols::to_string(atom_t atom) {
     switch(atom) {
-        case atom_t::H: return "H";
+        case atom_t::H:  return "H";
         case atom_t::He: return "He";
         case atom_t::Li: return "Li";
         case atom_t::Be: return "Be";
-        case atom_t::B: return "B";
-        case atom_t::C: return "C";
-        case atom_t::N: return "N";
-        case atom_t::O: return "O";
-        case atom_t::F: return "F";
+        case atom_t::B:  return "B";
+        case atom_t::C:  return "C";
+        case atom_t::N:  return "N";
+        case atom_t::O:  return "O";
+        case atom_t::F:  return "F";
         case atom_t::Ne: return "Ne";
         case atom_t::Na: return "Na";
         case atom_t::Mg: return "Mg";
         case atom_t::Al: return "Al";
         case atom_t::Si: return "Si";
-        case atom_t::P: return "P";
-        case atom_t::S: return "S";
+        case atom_t::P:  return "P";
+        case atom_t::S:  return "S";
         case atom_t::Cl: return "Cl";
         case atom_t::Ar: return "Ar";
-        case atom_t::K: return "K";
+        case atom_t::K:  return "K";
         case atom_t::Ca: return "Ca";
         case atom_t::Sc: return "Sc";
         case atom_t::Ti: return "Ti";
-        case atom_t::V: return "V";
+        case atom_t::V:  return "V";
         case atom_t::Cr: return "Cr";
         case atom_t::Mn: return "Mn";
         case atom_t::Fe: return "Fe";
@@ -236,9 +245,13 @@ std::string ausaxs::constants::symbols::to_string(atom_t atom) {
         case atom_t::Ni: return "Ni";
         case atom_t::Cu: return "Cu";
         case atom_t::Zn: return "Zn";
-        case atom_t::I: return "I";
-        case atom_t::W: return "W";
-        case atom_t::M: return "M";
+        case atom_t::Ga: return "Ga";
+        case atom_t::Ge: return "Ge";
+        case atom_t::As: return "As";
+        case atom_t::Se: return "Se";
+        case atom_t::I:  return "I";
+        case atom_t::W:  return "W";
+        case atom_t::M:  return "M";
         case atom_t::dummy: return "#";
         default: throw std::runtime_error("constants::symbols::to_string: Unknown atom type \"" + std::to_string(static_cast<int>(atom)) + "\"");
     }

--- a/source/core/constants/Constants.cpp
+++ b/source/core/constants/Constants.cpp
@@ -37,16 +37,21 @@ namespace ausaxs::constants {
     }
 
     std::string symbols::hydrogen = "H";
-    std::string symbols::carbon = "C";
+    std::string symbols::carbon   = "C";
     std::string symbols::nitrogen = "N";
-    std::string symbols::oxygen = "O";
+    std::string symbols::oxygen   = "O";
 
     const saxs::detail::SimpleMap<constants::atom_t> symbols::detail::string_to_atomt_map = std::unordered_map<std::string, constants::atom_t>{
-        {"H", atom_t::H},   {"He", atom_t::He}, {"Li", atom_t::Li}, {"Be", atom_t::Be}, {"B", atom_t::B},   {"C", atom_t::C},   {"N", atom_t::N}, {"O", atom_t::O}, 
-        {"F", atom_t::F},   {"Ne", atom_t::Ne}, {"Na", atom_t::Na}, {"Mg", atom_t::Mg}, {"Al", atom_t::Al}, {"Si", atom_t::Si}, {"P", atom_t::P}, {"S", atom_t::S}, 
-        {"Cl", atom_t::Cl}, {"Ar", atom_t::Ar}, {"K", atom_t::K},   {"Ca", atom_t::Ca}, {"Sc", atom_t::Sc}, {"Ti", atom_t::Ti}, {"V", atom_t::V}, {"Cr", atom_t::Cr}, 
-        {"Mn", atom_t::Mn}, {"Fe", atom_t::Fe}, {"Co", atom_t::Co}, {"Ni", atom_t::Ni}, {"Cu", atom_t::Cu}, {"Zn", atom_t::Zn}, {"Ga", atom_t::Ga}, {"Ge", atom_t::Ge}, 
-        {"As", atom_t::As}, {"Se", atom_t::Se}, {"I", atom_t::I},   {"W", atom_t::W},   {"M", atom_t::M}
+        {"H", atom_t::H},   {"He", atom_t::He}, 
+        {"Li", atom_t::Li}, {"Be", atom_t::Be}, {"B", atom_t::B},   {"C", atom_t::C},   {"N", atom_t::N}, {"O", atom_t::O}, {"F", atom_t::F},   {"Ne", atom_t::Ne}, 
+        {"Na", atom_t::Na}, {"Mg", atom_t::Mg}, {"Al", atom_t::Al}, {"Si", atom_t::Si}, {"P", atom_t::P}, {"S", atom_t::S}, {"Cl", atom_t::Cl}, {"Ar", atom_t::Ar}, 
+        {"K",  atom_t::K},  {"Ca", atom_t::Ca}, {"Sc", atom_t::Sc}, {"Ti", atom_t::Ti}, {"V", atom_t::V}, {"Cr", atom_t::Cr}, {"Mn", atom_t::Mn}, {"Fe", atom_t::Fe}, 
+        {"Co", atom_t::Co}, {"Ni", atom_t::Ni}, {"Cu", atom_t::Cu}, {"Zn", atom_t::Zn}, {"Ga", atom_t::Ga}, {"Ge", atom_t::Ge}, {"As", atom_t::As}, {"Se", atom_t::Se}, 
+        {"Br", atom_t::Br}, {"Kr", atom_t::Kr}, 
+        {"Rb", atom_t::Rb}, {"Sr", atom_t::Sr}, {"Y",  atom_t::Y},  {"Zr", atom_t::Zr}, {"Nb", atom_t::Nb}, {"Mo", atom_t::Mo}, {"Tc", atom_t::Tc}, {"Ru", atom_t::Ru}, 
+        {"Rh", atom_t::Rh}, {"Pd", atom_t::Pd}, {"Ag", atom_t::Ag}, {"Cd", atom_t::Cd}, {"In", atom_t::In}, {"Sn", atom_t::Sn}, {"Sb", atom_t::Sb}, {"Te", atom_t::Te},
+        {"I",  atom_t::I},  {"Xe", atom_t::Xe}, 
+        {"W",  atom_t::W},  {"M", atom_t::M}
     };
 
     residue::ResidueStorage hydrogen_atoms::residues;
@@ -100,6 +105,7 @@ unsigned int constants::charge::nuclear::get_charge(atom_t atom) {
     switch(atom) {
         case atom_t::H:  return 1;
         case atom_t::He: return 2;
+
         case atom_t::Li: return 3;
         case atom_t::Be: return 4;
         case atom_t::B:  return 5;
@@ -108,6 +114,7 @@ unsigned int constants::charge::nuclear::get_charge(atom_t atom) {
         case atom_t::O:  return 8;
         case atom_t::F:  return 9;
         case atom_t::Ne: return 10;
+
         case atom_t::Na: return 11;
         case atom_t::Mg: return 12;
         case atom_t::Al: return 13;
@@ -116,6 +123,7 @@ unsigned int constants::charge::nuclear::get_charge(atom_t atom) {
         case atom_t::S:  return 16;
         case atom_t::Cl: return 17;
         case atom_t::Ar: return 18;
+
         case atom_t::K:  return 19;
         case atom_t::Ca: return 20;
         case atom_t::Sc: return 21;
@@ -132,7 +140,28 @@ unsigned int constants::charge::nuclear::get_charge(atom_t atom) {
         case atom_t::Ge: return 32;
         case atom_t::As: return 33;
         case atom_t::Se: return 34;
+        case atom_t::Br: return 35;
+        case atom_t::Kr: return 36;
+
+        case atom_t::Rb: return 37;
+        case atom_t::Sr: return 38;
+        case atom_t::Y:  return 39;
+        case atom_t::Zr: return 40;
+        case atom_t::Nb: return 41;
+        case atom_t::Mo: return 42;
+        case atom_t::Tc: return 43;
+        case atom_t::Ru: return 44;
+        case atom_t::Rh: return 45;
+        case atom_t::Pd: return 46;
+        case atom_t::Ag: return 47;
+        case atom_t::Cd: return 48;
+        case atom_t::In: return 49;
+        case atom_t::Sn: return 50;
+        case atom_t::Sb: return 51;
+        case atom_t::Te: return 52;
         case atom_t::I:  return 53;
+        case atom_t::Xe: return 54;
+
         case atom_t::W:  return 74;
         case atom_t::M:  return 0;
         case atom_t::dummy: return 1;
@@ -173,6 +202,7 @@ double constants::radius::get_vdw_radius(atom_t atom) {
         case atom_t::He: return vdw::He;
         case atom_t::Ne: return vdw::Ne;
         case atom_t::Ar: return vdw::Ar;
+
         case atom_t::Li: return vdw::Li;
         case atom_t::Be: return vdw::Be;
         case atom_t::B:  return vdw::B;
@@ -180,6 +210,7 @@ double constants::radius::get_vdw_radius(atom_t atom) {
         case atom_t::N:  return vdw::N;
         case atom_t::O:  return vdw::O;
         case atom_t::F:  return vdw::F;
+
         case atom_t::Na: return vdw::Na;
         case atom_t::Mg: return vdw::Mg;
         case atom_t::Al: return vdw::Al;
@@ -187,6 +218,7 @@ double constants::radius::get_vdw_radius(atom_t atom) {
         case atom_t::P:  return vdw::P;
         case atom_t::S:  return vdw::S;
         case atom_t::Cl: return vdw::Cl;
+
         case atom_t::K:  return vdw::K;
         case atom_t::Ca: return vdw::Ca;
         case atom_t::Sc: return vdw::Sc;
@@ -203,7 +235,26 @@ double constants::radius::get_vdw_radius(atom_t atom) {
         case atom_t::Ge: return vdw::Ge;
         case atom_t::As: return vdw::As;
         case atom_t::Se: return vdw::Se;
+        case atom_t::Br: return vdw::Br;
+
+        case atom_t::Rb: return vdw::Rb;
+        case atom_t::Sr: return vdw::Sr;
+        case atom_t::Y:  return vdw::Y;
+        case atom_t::Zr: return vdw::Zr;
+        case atom_t::Nb: return vdw::Nb;
+        case atom_t::Mo: return vdw::Mo;
+        case atom_t::Tc: return vdw::Tc;
+        case atom_t::Ru: return vdw::Ru;
+        case atom_t::Rh: return vdw::Rh;
+        case atom_t::Pd: return vdw::Pd;
+        case atom_t::Ag: return vdw::Ag;
+        case atom_t::Cd: return vdw::Cd;
+        case atom_t::In: return vdw::In;
+        case atom_t::Sn: return vdw::Sn;
+        case atom_t::Sb: return vdw::Sb;
+        case atom_t::Te: return vdw::Te;
         case atom_t::I:  return vdw::I;
+
         case atom_t::W:  return vdw::W;
 
         // fake elements
@@ -217,6 +268,7 @@ std::string ausaxs::constants::symbols::to_string(atom_t atom) {
     switch(atom) {
         case atom_t::H:  return "H";
         case atom_t::He: return "He";
+
         case atom_t::Li: return "Li";
         case atom_t::Be: return "Be";
         case atom_t::B:  return "B";
@@ -225,6 +277,7 @@ std::string ausaxs::constants::symbols::to_string(atom_t atom) {
         case atom_t::O:  return "O";
         case atom_t::F:  return "F";
         case atom_t::Ne: return "Ne";
+
         case atom_t::Na: return "Na";
         case atom_t::Mg: return "Mg";
         case atom_t::Al: return "Al";
@@ -233,6 +286,7 @@ std::string ausaxs::constants::symbols::to_string(atom_t atom) {
         case atom_t::S:  return "S";
         case atom_t::Cl: return "Cl";
         case atom_t::Ar: return "Ar";
+
         case atom_t::K:  return "K";
         case atom_t::Ca: return "Ca";
         case atom_t::Sc: return "Sc";
@@ -249,7 +303,27 @@ std::string ausaxs::constants::symbols::to_string(atom_t atom) {
         case atom_t::Ge: return "Ge";
         case atom_t::As: return "As";
         case atom_t::Se: return "Se";
+        case atom_t::Br: return "Br";
+
+        case atom_t::Rb: return "Rb";
+        case atom_t::Sr: return "Sr";
+        case atom_t::Y:  return "Y";
+        case atom_t::Zr: return "Zr";
+        case atom_t::Nb: return "Nb";
+        case atom_t::Mo: return "Mo";
+        case atom_t::Tc: return "Tc";
+        case atom_t::Ru: return "Ru";
+        case atom_t::Rh: return "Rh";
+        case atom_t::Pd: return "Pd";
+        case atom_t::Ag: return "Ag";
+        case atom_t::Cd: return "Cd";
+        case atom_t::In: return "In";
+        case atom_t::Sn: return "Sn";
+        case atom_t::Sb: return "Sb";
+        case atom_t::Te: return "Te";
         case atom_t::I:  return "I";
+        case atom_t::Xe: return "Xe";
+
         case atom_t::W:  return "W";
         case atom_t::M:  return "M";
         case atom_t::dummy: return "#";


### PR DESCRIPTION
This PR will add support for parsing additional atomic types. 

Most of them cannot yet be used for scattering calculations, as their typical bond number can only be deduced after seeing them used in actual ligands. 