### PR TITLE
em_fitter bugfixing

### DIFF
--- a/executable/em_fitter.cpp
+++ b/executable/em_fitter.cpp
@@ -68,6 +68,7 @@ int main(int argc, char const *argv[]) {
         if (!constants::filetypes::saxs_data.check(mfile)) {
             throw except::invalid_argument("Unknown SAXS data extension: \"" + mfile.str() + "\"");
         }
+        if (!settings::em::hydrate) {settings::fit::fit_hydration = false;} 
         if (!settings::general::output.empty() && settings::general::output.back() != '/') {settings::general::output += "/";}
         settings::general::output += mfile.stem() + "/" + mapfile.stem() + "/";
 

--- a/include/core/data/Molecule.h
+++ b/include/core/data/Molecule.h
@@ -60,7 +60,7 @@ namespace ausaxs::data {
 			/** 
 			 * @brief Writes this body to disk.
 			 */
-			void save(const io::File& path);
+			void save(const io::File& path) const;
 
 			/** 
 			 * @brief Use an algorithm to generate a new hydration layer for this body. Note that the previous one will be deleted.

--- a/include/core/data/atoms/Atom.h
+++ b/include/core/data/atoms/Atom.h
@@ -35,7 +35,7 @@ namespace ausaxs::data {
      */
     struct Atom : detail::AtomForwarder<Atom> {
         Atom() = default;
-        Atom(const Vector3<precision_t>& coords, precision_t weight) : coords(coords), w(weight) {}
+        Atom(Vector3<precision_t> coords, precision_t weight) : coords(std::move(coords)), w(weight) {}
         [[nodiscard]] const Atom& get_atom() const {return *this;}
         [[nodiscard]] Atom& get_atom() {return *this;}
         bool operator==(const Atom& rhs) const = default;

--- a/include/core/data/atoms/AtomFF.h
+++ b/include/core/data/atoms/AtomFF.h
@@ -10,9 +10,9 @@ namespace ausaxs::data {
     class AtomFF : public detail::AtomForwarder<AtomFF> {
         public:
             AtomFF() = default;
-            AtomFF(const Atom& a, form_factor::form_factor_t t) : basic(a), type(t) {}
-            AtomFF(const Vector3<precision_t>& coords, form_factor::form_factor_t t) : basic(coords, constants::charge::nuclear::get_charge(t)), type(t) {}
-            AtomFF(const Vector3<precision_t>& coords, form_factor::form_factor_t t, double weight) : basic(coords, weight), type(t) {}
+            AtomFF(Atom a, form_factor::form_factor_t t) : basic(std::move(a)), type(t) {}
+            AtomFF(Vector3<precision_t> coords, form_factor::form_factor_t t) : basic(coords, constants::charge::nuclear::get_charge(t)), type(t) {}
+            AtomFF(Vector3<precision_t> coords, form_factor::form_factor_t t, double weight) : basic(coords, weight), type(t) {}
             Atom& get_atom() {return basic;}
             const Atom& get_atom() const {return basic;}
 

--- a/include/core/data/atoms/Water.h
+++ b/include/core/data/atoms/Water.h
@@ -8,7 +8,7 @@ namespace ausaxs::data {
      */
     struct Water : detail::AtomForwarder<Water> {
         Water() = default;
-        Water(const Vector3<precision_t>& coords) : coords(coords), w(constants::charge::nuclear::get_charge(form_factor_type())) {}
+        Water(Vector3<precision_t> coords) : coords(std::move(coords)), w(constants::charge::nuclear::get_charge(form_factor_type())) {}
 
         form_factor::form_factor_t form_factor_type() const {return form_factor::form_factor_t::OH;}
         [[nodiscard]] const Water& get_atom() const {return *this;}

--- a/include/core/form_factor/FormFactorType.h
+++ b/include/core/form_factor/FormFactorType.h
@@ -44,10 +44,10 @@ namespace ausaxs::form_factor {
             case form_factor_t::OH: return "OH";
             case form_factor_t::S: return "S";
             case form_factor_t::SH: return "SH";
-            case form_factor_t::OTHER: return "other";
-            case form_factor_t::EXCLUDED_VOLUME: return "excluded volume";
-            case form_factor_t::COUNT: return "count";
-            case form_factor_t::UNKNOWN: return "unknown";
+            case form_factor_t::OTHER: return "OTH";
+            case form_factor_t::EXCLUDED_VOLUME: return "EXV";
+            case form_factor_t::COUNT: return "CNT";
+            case form_factor_t::UNKNOWN: return "UNK";
             default: throw std::runtime_error("form_factor::to_string: Invalid form factor type (enum " + std::to_string(static_cast<int>(type)) + ")");
         }
     }

--- a/include/core/hist/histogram_manager/PartialHistogramManagerMT.h
+++ b/include/core/hist/histogram_manager/PartialHistogramManagerMT.h
@@ -44,19 +44,19 @@ namespace ausaxs::hist {
 			 * @brief Calculate the self-correlation of a body.
 			 * 		  This only adds jobs to the thread pool, and does not wait for them to complete.
 			 */
-			void calc_self_correlation(calculator_t calculator, unsigned int index);
+			void calc_self_correlation(calculator_t calculator, int index);
 
 			/**
 			 * @brief Calculate the atom-atom distances between body @a n and @a m. 
 			 * 		  This only adds jobs to the thread pool, and does not wait for them to complete.
 			 */
-			void calc_aa(calculator_t calculator, unsigned int n, unsigned int m);
+			void calc_aa(calculator_t calculator, int n, int m);
 
 			/**
 			 * @brief Calculate the hydration-atom distances between the hydration layer and body @a index.
 			 * 		  This only adds jobs to the thread pool, and does not wait for them to complete.
 			 */
-			void calc_aw(calculator_t calculator, unsigned int index);
+			void calc_aw(calculator_t calculator, int index);
 
 			/**
 			 * @brief Calculate the hydration-hydration distances. 
@@ -66,9 +66,9 @@ namespace ausaxs::hist {
 
 			void combine_self_correlation(int index, GenericDistribution1D_t&&);
 
-			void combine_aa(unsigned int n, unsigned int m, GenericDistribution1D_t&&);
+			void combine_aa(int n, int m, GenericDistribution1D_t&&);
 
-			void combine_aw(unsigned int index, GenericDistribution1D_t&&);
+			void combine_aw(int index, GenericDistribution1D_t&&);
 
 			void combine_ww(GenericDistribution1D_t&&);
 
@@ -77,7 +77,7 @@ namespace ausaxs::hist {
 			 * 
 			 * @param index The index of the body to update.
 			 */
-			void update_compact_representation_body(unsigned int index);
+			void update_compact_representation_body(int index);
 
 			/**
 			 * @brief Update the compact representation of the coordinates of the hydration layer.

--- a/include/em/em/detail/EMAtom.h
+++ b/include/em/em/detail/EMAtom.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <data/atoms/Atom.h>
+#include <data/atoms/AtomFF.h>
 #include <form_factor/FormFactorType.h>
 
 namespace ausaxs::data {
@@ -14,6 +15,7 @@ namespace ausaxs::data {
             EMAtom(const Vector3<precision_t>& coords, double weight, double density) : basic(coords, weight), density(density) {}
             Atom& get_atom() {return basic.get_atom();}
             const Atom& get_atom() const {return basic.get_atom();}
+            AtomFF get_atom_ff() const {return AtomFF{basic, form_factor::form_factor_t::UNKNOWN};}
 
             [[nodiscard]] double charge_density() const {return density;}
             [[nodiscard]] double& charge_density() {return density;}

--- a/include/em/em/detail/EMGrid.h
+++ b/include/em/em/detail/EMGrid.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <grid/Grid.h>
+
+namespace ausaxs::em::grid {
+    /**
+     * @brief A customized grid for EM maps. 
+     *
+     * This grid has been modified to use the EM map resolution as the minimum atomic radius.
+     * This is necessary to circumvent the expanded radius becoming 0 for the map atoms with the "unknown" form factor.
+     */
+    class EMGrid : public ausaxs::grid::Grid {
+        public:
+            using Grid::Grid;
+            ~EMGrid() = default;
+
+            double get_atomic_radius(form_factor::form_factor_t) const override;
+    };
+}

--- a/include/em/em/detail/ImageStackBase.h
+++ b/include/em/em/detail/ImageStackBase.h
@@ -96,14 +96,6 @@ namespace ausaxs::em {
             const std::vector<Image>& images() const;
 
             /**
-             * @brief Save this structure as a .pdb file. 
-             * 
-             * @param cutoff The cutoff value. If positive, atoms will be generated at all pixel values higher than this. If negative, they will be generated at pixels lower than this. 
-             * @param path Path to save location.
-             */
-            void save(double cutoff, const io::File& path) const;
-
-            /**
              * @brief Get the mean density.
              */
             double mean() const;

--- a/include/em/em/manager/ProteinManager.h
+++ b/include/em/em/manager/ProteinManager.h
@@ -36,6 +36,21 @@ namespace ausaxs::em {
                 virtual std::unique_ptr<hist::ICompositeDistanceHistogram> get_histogram(double cutoff) = 0;
 
                 /**
+                 * @brief Get the excluded volume mass of the managed molecule.
+                 * 		  This is the excluded volume of the molecule times the average protein mass density. 
+                 * 
+                 * @return The excluded volume mass in Da.
+                 */
+                double get_excluded_volume_mass() const;
+
+                /**
+                 * @brief Calculate the volume of the managed molecule based on the number of grid bins it spans.
+                 * 
+                 * @return The volume in Å^3.
+                 */
+                double get_volume_grid() const;
+
+                /**
                  * @brief Set the charge levels.
                  */
                 virtual void set_charge_levels(const std::vector<double>& levels) noexcept;

--- a/include/em/em/manager/ProteinManager.h
+++ b/include/em/em/manager/ProteinManager.h
@@ -24,7 +24,6 @@ namespace ausaxs::em {
                  * @brief Get the Protein backing this object. 
                  */
                 virtual observer_ptr<const data::Molecule> get_protein() const = 0;
-                observer_ptr<data::Molecule> get_protein();
 
                 /**
                  * @brief Get the Protein generated from a given cutoff.

--- a/include/em/em/manager/ProteinManager.h
+++ b/include/em/em/manager/ProteinManager.h
@@ -24,6 +24,7 @@ namespace ausaxs::em {
                  * @brief Get the Protein backing this object. 
                  */
                 virtual observer_ptr<const data::Molecule> get_protein() const = 0;
+                observer_ptr<data::Molecule> get_protein();
 
                 /**
                  * @brief Get the Protein generated from a given cutoff.

--- a/include/em/em/manager/SmartProteinManager.h
+++ b/include/em/em/manager/SmartProteinManager.h
@@ -54,7 +54,10 @@ namespace ausaxs::em::managers {
             virtual void update_protein(double cutoff);
 
             /**
-             * @brief Enable or disable the histogram manager initialization for generated proteins.
+             * @brief Enable or disable the histogram manager initialization for generated molecules.
+             * 
+             * This is used to prevent expensive initialization of the histogram managers whenever a new 
+             * molecule is generated, since they will be cannibalized by the member variable anyway. 
              */
             void toggle_histogram_manager_init(bool state);
 

--- a/source/core/data/Molecule.cpp
+++ b/source/core/data/Molecule.cpp
@@ -81,7 +81,7 @@ SimpleDataset Molecule::simulate_dataset(bool add_noise) const {
     return data;
 }
 
-void Molecule::save(const io::File& path) {
+void Molecule::save(const io::File& path) const {
     io::Writer::write({*this}, path);
 }
 

--- a/source/core/data/Molecule.cpp
+++ b/source/core/data/Molecule.cpp
@@ -360,7 +360,16 @@ void Molecule::bind_body_signallers() {
     if (phm == nullptr) {return;}
 
     auto cast = dynamic_cast<hist::IPartialHistogramManager*>(phm.get());
-    if (!cast) {return;}
+    if (!cast) {
+        // The caller requested the body signalling objects to be (re)bound, but the histogram manager
+        // does not support this. To avoid leaving the bodies in a potentially dangerous state, we
+        // register a new dummy signaller to all bodies. 
+        for (unsigned int i = 0; i < bodies.size(); i++) {
+            bodies[i].register_probe(std::make_shared<signaller::UnboundSignaller>());
+        }
+        return;
+    }
+
     assert(cast->body_size == size_body() && "Molecule::bind_body_signallers: body size mismatch.");
     for (unsigned int i = 0; i < bodies.size(); i++) {
         bodies[i].register_probe(cast->get_probe(i));

--- a/source/core/fitter/SmartFitter.cpp
+++ b/source/core/fitter/SmartFitter.cpp
@@ -100,6 +100,11 @@ std::unique_ptr<FitResult> SmartFitter::fit() {
     validate_model(model.get());
     if (guess.empty()) {guess = get_default_guess();}
 
+    if (get_number_of_enabled_pars() == 0) {
+        auto linear_fitter = prepare_linear_fitter({});
+        return linear_fitter.fit();    
+    }
+
     auto f = std::bind(&SmartFitter::chi2, this, std::placeholders::_1);
     auto mini = mini::create_minimizer(algorithm, std::move(f), guess);
     auto res = mini->minimize();

--- a/source/core/grid/Grid.cpp
+++ b/source/core/grid/Grid.cpp
@@ -91,7 +91,7 @@ void Grid::setup() {
 
     // enforce minimum number of bins if set
     if (settings::grid::min_bins != 0) {
-        double min_length = settings::grid::min_bins*settings::grid::cell_width/2;
+        double min_length = 0.5*settings::grid::min_bins*settings::grid::cell_width;
         if (axes.x.bins < settings::grid::min_bins) {
             axes.x.bins = settings::grid::min_bins;
             axes.x.min = -min_length;
@@ -370,6 +370,10 @@ void Grid::remove_waters(const std::vector<bool>& to_remove) {
 std::span<GridMember<AtomFF>> Grid::add(const Body& body, bool expand) {
     int start = a_members.size();
     body_start[body.get_uid()] = start;
+    if (body.size_atom() == 0) {
+        return {a_members.begin(), a_members.end()};
+    }
+
     a_members.resize(a_members.size() + body.symmetry().size_atom_total());
     auto b_atoms = body.symmetry().explicit_structure().atoms;
 

--- a/source/core/hist/histogram_manager/PartialSymmetryManagerMT.cpp
+++ b/source/core/hist/histogram_manager/PartialSymmetryManagerMT.cpp
@@ -47,17 +47,19 @@ PartialSymmetryManagerMT<use_weighted_distribution>::PartialSymmetryManagerMT(ob
 template<bool use_weighted_distribution> 
 PartialSymmetryManagerMT<use_weighted_distribution>::~PartialSymmetryManagerMT() = default;
 
-int water_res_index = 1.31e8;
-int to_res_index(int body1, int symmetry1, int body2, int symmetry2) {
-    return symmetry2 + body2*1e2 + symmetry1*1e4 + body1*1e6;
-}
+namespace {
+    int water_res_index = 1.31e8;
+    int to_res_index(int body1, int symmetry1, int body2, int symmetry2) {
+        return symmetry2 + body2*1e2 + symmetry1*1e4 + body1*1e6;
+    }
 
-int to_res_index_self(int body, int symmetry) {
-    return to_res_index(body, symmetry, body, symmetry);
-}
+    int to_res_index_self(int body, int symmetry) {
+        return to_res_index(body, symmetry, body, symmetry);
+    }
 
-int to_res_index_water(int body, int symmetry) {
-    return to_res_index_self(body, symmetry) + water_res_index;
+    int to_res_index_water(int body, int symmetry) {
+        return to_res_index_self(body, symmetry) + water_res_index;
+    }    
 }
 
 template<bool use_weighted_distribution>

--- a/source/em/CMakeLists.txt
+++ b/source/em/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(ausaxs_em OBJECT
 
 	"detail/ImageStackBase.cpp"
 	"detail/EMFitResult.cpp"
+	"detail/EMGrid.cpp"
 	"detail/header/DummyHeader.cpp"
 	"detail/header/HeaderFactory.cpp"
 	"detail/header/MapHeader.cpp"
@@ -14,12 +15,12 @@ add_library(ausaxs_em OBJECT
 	"detail/header/data/HeaderData.cpp"
 	"detail/header/data/MRCData.cpp"
 	"detail/header/data/RECData.cpp"
-	
+
 	"manager/ProteinManager.cpp"
 	"manager/ProteinManagerFactory.cpp"
 	"manager/SimpleProteinManager.cpp"
 	"manager/SmartProteinManager.cpp"
-	
+
 	"plots/PlotImage.cpp"
 )
 

--- a/source/em/Image.cpp
+++ b/source/em/Image.cpp
@@ -44,13 +44,14 @@ std::list<data::EMAtom> Image::generate_atoms(double cutoff) const {
     // define a weight function for more efficient switching. 
     auto weight = settings::em::fixed_weights ? 
         [] (float) {return 1.0f;} :     // fixed weights enabled - all voxels have the same weight of 1
-        [] (float val) {return val;};   // fixed weights disabled - voxels have a weight equal to their density
-    
+        [] (float val) {return val;}   // fixed weights disabled - voxels have a weight equal to their density
+    ;
+
     for (int x = 0; x < static_cast<int>(N); x += step) {
         for (int y = static_cast<int>(bounds[x].min); y < static_cast<int>(bounds[x].max); y += step) {
             float val = index(x, y);
             if (val < cutoff) {continue;}
-            atoms.emplace_back(Vector3{x*xscale, y*yscale, z*zscale}, weight(val), val);
+            atoms.emplace_back(Vector3<double>{x*xscale, y*yscale, z*zscale}, weight(val), val);
         }
     }
     return atoms;

--- a/source/em/ImageStack.cpp
+++ b/source/em/ImageStack.cpp
@@ -95,17 +95,11 @@ std::function<double(std::vector<double>)> ImageStack::prepare_function(std::sha
             last_c = last_fit->get_parameter(constants::fit::Parameters::SCALING_WATER).value;            // update c for next iteration
             evals.push_back(detail::ExtendedLandscape(params[0], mass, get_protein_manager()->get_volume_grid(), std::move(last_fit->evaluated_points)));  // record evaluated points
         } else {
-            auto mass = get_protein_manager()->get_excluded_volume_mass()/1e3;      // mass in kDa
             fitter->set_model(get_protein_manager()->get_histogram(params[0]));
+            auto mass = get_protein_manager()->get_excluded_volume_mass()/1e3;      // mass in kDa
             last_fit = fitter->fit();
             evals.push_back(detail::ExtendedLandscape(params[0], mass, get_protein_manager()->get_volume_grid(), std::move(last_fit->evaluated_points)));  // record evaluated points
         }
-
-        std::cout << "Fitted pars: " << std::endl;
-        for (const auto& p : last_fit->get_parameters()) {
-            std::cout << p.name << ": " << p.value << std::endl;
-        }
-        std::cout << "Fitted chi2: " << last_fit->fval << std::endl;
 
         double val = last_fit->fval;
         progress.notify(counter++);

--- a/source/em/ImageStack.cpp
+++ b/source/em/ImageStack.cpp
@@ -83,28 +83,29 @@ std::function<double(std::vector<double>)> ImageStack::prepare_function(std::sha
     // 'this' is ok since prepare_function is private and thus only used within the class itself
     hydrate::RadialHydration::set_noise_generator([] () {return Vector3<double>{0, 0, 0};}); // ensure hydration shell is deterministic
     return [this, fitter = std::move(_fitter)] (const std::vector<double>& params) -> double {
-        auto p = get_protein_manager()->get_protein(params[0]);
         if (settings::em::hydrate) {
-            p->clear_grid();                // clear grid from previous iteration
-            p->generate_new_hydration();    // generate a new hydration layer
-
             // pointer cast is ok since the type should always be HydrationFitter when hydration is enabled
             fitter->set_guess({mini::Parameter{constants::fit::to_string(constants::fit::Parameters::SCALING_WATER), last_c, {0, 200}}});
             fitter->set_algorithm(mini::algorithm::SCAN);
-            fitter->set_model(p->get_histogram());
+            fitter->set_model(get_protein_manager()->get_histogram(params[0]));
 
-            auto mass = p->get_excluded_volume_mass()/1e3;                                                // mass in kDa
+            auto mass = get_protein_manager()->get_excluded_volume_mass()/1e3;                                                // mass in kDa
             last_fit = fitter->fit();                                                                     // do the fit
             water_factors.push_back(last_fit->get_parameter(constants::fit::Parameters::SCALING_WATER));  // record c value
             last_c = last_fit->get_parameter(constants::fit::Parameters::SCALING_WATER).value;            // update c for next iteration
-            evals.push_back(detail::ExtendedLandscape(params[0], mass, p->get_volume_grid(), std::move(last_fit->evaluated_points)));  // record evaluated points
+            evals.push_back(detail::ExtendedLandscape(params[0], mass, get_protein_manager()->get_volume_grid(), std::move(last_fit->evaluated_points)));  // record evaluated points
         } else {
-            p->clear_grid();                                    // clear grid from previous iteration
-            auto mass = p->get_excluded_volume_mass()/1e3;      // mass in kDa
-            fitter->set_model(p->get_histogram());
+            auto mass = get_protein_manager()->get_excluded_volume_mass()/1e3;      // mass in kDa
+            fitter->set_model(get_protein_manager()->get_histogram(params[0]));
             last_fit = fitter->fit();
-            evals.push_back(detail::ExtendedLandscape(params[0], mass, p->get_volume_grid(), std::move(last_fit->evaluated_points)));  // record evaluated points
+            evals.push_back(detail::ExtendedLandscape(params[0], mass, get_protein_manager()->get_volume_grid(), std::move(last_fit->evaluated_points)));  // record evaluated points
         }
+
+        std::cout << "Fitted pars: " << std::endl;
+        for (const auto& p : last_fit->get_parameters()) {
+            std::cout << p.name << ": " << p.value << std::endl;
+        }
+        std::cout << "Fitted chi2: " << last_fit->fval << std::endl;
 
         double val = last_fit->fval;
         progress.notify(counter++);

--- a/source/em/detail/EMGrid.cpp
+++ b/source/em/detail/EMGrid.cpp
@@ -1,0 +1,8 @@
+#include <em/detail/EMGrid.h>
+#include <settings/GridSettings.h>
+
+using namespace ausaxs::em::grid;
+
+double EMGrid::get_atomic_radius(form_factor::form_factor_t) const {
+    return settings::grid::min_exv_radius;
+}

--- a/source/em/detail/ImageStackBase.cpp
+++ b/source/em/detail/ImageStackBase.cpp
@@ -65,11 +65,6 @@ ImageStackBase::ImageStackBase(const io::ExistingFile& file) {
 
 ImageStackBase::~ImageStackBase() = default;
 
-void ImageStackBase::save(double cutoff, const io::File& path) const {
-    auto protein = get_protein_manager()->get_protein(cutoff);
-    protein->save(path);
-}
-
 Image& ImageStackBase::image(unsigned int layer) {return data[layer];}
 
 const Image& ImageStackBase::image(unsigned int layer) const {return data[layer];}

--- a/source/em/manager/ProteinManager.cpp
+++ b/source/em/manager/ProteinManager.cpp
@@ -24,6 +24,10 @@ ProteinManager::ProteinManager(observer_ptr<const em::ImageStackBase> images) : 
     set_charge_levels(axis.as_vector());
 }
 
+observer_ptr<data::Molecule> ProteinManager::get_protein() {
+    return const_cast<observer_ptr<data::Molecule>>(const_cast<const ProteinManager*>(this)->get_protein());
+}
+
 double ProteinManager::get_volume_grid() const {
     auto protein = get_protein();
     assert(protein != nullptr && "ProteinManager::get_volume_grid: protein is null");

--- a/source/em/manager/ProteinManager.cpp
+++ b/source/em/manager/ProteinManager.cpp
@@ -24,10 +24,6 @@ ProteinManager::ProteinManager(observer_ptr<const em::ImageStackBase> images) : 
     set_charge_levels(axis.as_vector());
 }
 
-observer_ptr<data::Molecule> ProteinManager::get_protein() {
-    return const_cast<observer_ptr<data::Molecule>>(const_cast<const ProteinManager*>(this)->get_protein());
-}
-
 double ProteinManager::get_volume_grid() const {
     auto protein = get_protein();
     assert(protein != nullptr && "ProteinManager::get_volume_grid: protein is null");

--- a/source/em/manager/ProteinManager.cpp
+++ b/source/em/manager/ProteinManager.cpp
@@ -4,8 +4,9 @@ For more information, please refer to the LICENSE file in the project root.
 */
 
 #include <em/manager/ProteinManager.h>
-#include <utility/Axis.h>
 #include <em/ImageStack.h>
+#include <data/Molecule.h>
+#include <utility/Axis.h>
 #include <settings/EMSettings.h>
 #include <settings/MoleculeSettings.h>
 
@@ -22,6 +23,18 @@ ProteinManager::ProteinManager(observer_ptr<const em::ImageStackBase> images) : 
     Axis axis(min, max, settings::em::charge_levels);
     set_charge_levels(axis.as_vector());
 }
+
+double ProteinManager::get_volume_grid() const {
+    auto protein = get_protein();
+    assert(protein != nullptr && "ProteinManager::get_volume_grid: protein is null");
+    return protein->get_volume_grid();
+}
+
+double ProteinManager::get_excluded_volume_mass() const {
+    auto protein = get_protein();
+    assert(protein != nullptr && "ProteinManager::get_excluded_volume_mass: protein is null");
+    return protein->get_excluded_volume_mass();
+}    
 
 std::vector<double> ProteinManager::get_charge_levels() const noexcept {
     return charge_levels;

--- a/source/em/manager/SimpleProteinManager.cpp
+++ b/source/em/manager/SimpleProteinManager.cpp
@@ -13,6 +13,15 @@ using namespace ausaxs;
 
 void em::managers::SimpleProteinManager::update_protein(double cutoff) {
     auto atoms = generate_atoms(cutoff);
+
+    // this sorting step is principially not necessary, but required for consistency with SmartProteinManager
+    // otherwise we may see tiny differences in the generated hydration shells which breaks the tests
+    std::sort(
+        atoms.begin(), 
+        atoms.end(), 
+        [] (const data::EMAtom& atom1, const data::EMAtom& atom2) {return atom1.charge_density() < atom2.charge_density();}
+    );
+
     std::vector<data::AtomFF> converted(atoms.size());
     std::transform(atoms.begin(), atoms.end(), converted.begin(), [] (const data::EMAtom& atom) {return atom.get_atom_ff();});
     protein = std::make_unique<data::Molecule>(std::vector{data::Body{converted}});

--- a/source/em/manager/SimpleProteinManager.cpp
+++ b/source/em/manager/SimpleProteinManager.cpp
@@ -17,5 +17,4 @@ void em::managers::SimpleProteinManager::update_protein(double cutoff) {
     std::transform(atoms.begin(), atoms.end(), converted.begin(), [] (const data::EMAtom& atom) {return atom.get_atom_ff();});
     protein = std::make_unique<data::Molecule>(std::vector{data::Body{converted}});
     protein->set_histogram_manager(std::make_unique<hist::HistogramManagerMT<true>>(protein.get()));
-    std::cout << "SimpleProteinManager::update_protein: protein size: " << protein->size_atom() << std::endl;
 }

--- a/source/em/manager/SimpleProteinManager.cpp
+++ b/source/em/manager/SimpleProteinManager.cpp
@@ -13,8 +13,9 @@ using namespace ausaxs;
 
 void em::managers::SimpleProteinManager::update_protein(double cutoff) {
     auto atoms = generate_atoms(cutoff);
-    std::vector<data::Atom> converted(atoms.size());
-    std::transform(atoms.begin(), atoms.end(), converted.begin(), [] (const data::EMAtom& atom) {return atom.get_atom();});
+    std::vector<data::AtomFF> converted(atoms.size());
+    std::transform(atoms.begin(), atoms.end(), converted.begin(), [] (const data::EMAtom& atom) {return atom.get_atom_ff();});
     protein = std::make_unique<data::Molecule>(std::vector{data::Body{converted}});
     protein->set_histogram_manager(std::make_unique<hist::HistogramManagerMT<true>>(protein.get()));
+    std::cout << "SimpleProteinManager::update_protein: protein size: " << protein->size_atom() << std::endl;
 }

--- a/source/em/manager/SmartProteinManager.cpp
+++ b/source/em/manager/SmartProteinManager.cpp
@@ -107,7 +107,6 @@ void SmartProteinManager::update_protein(double cutoff) {
         protein = generate_protein(cutoff); 
         protein->bind_body_signallers();
         previous_cutoff = cutoff;
-        protein->set_grid(std::make_unique<grid::EMGrid>(protein->get_bodies()));
         toggle_histogram_manager_init(false);
         return;
     }
@@ -201,11 +200,6 @@ observer_ptr<data::Molecule> SmartProteinManager::get_protein(double cutoff) {
         protein->get_grid()->add(body);
     }
     if (settings::em::hydrate) {protein->generate_new_hydration();}
-
-    std::cout << "SmartProteinManager::get_protein: protein has been updated." << std::endl;
-    std::cout << "\tAtoms: " << protein->size_atom() << std::endl;
-    std::cout << "\tWaters: " << protein->size_water() << std::endl;
-
     return protein.get();
 }
 

--- a/source/em/manager/SmartProteinManager.cpp
+++ b/source/em/manager/SmartProteinManager.cpp
@@ -172,7 +172,6 @@ void SmartProteinManager::update_protein(double cutoff) {
                 break;
             }
         }
-
     }
 
     previous_cutoff = cutoff;

--- a/tests/em/image_stack.cpp
+++ b/tests/em/image_stack.cpp
@@ -74,7 +74,8 @@ TEST_CASE("ImageStack: test with sphere", "[broken]") {
 
 TEST_CASE("ImageStack::get_protein") {
     settings::molecule::center = false;
-
+    settings::grid::min_bins = 100;
+    
     SECTION("em_weights") {
         SECTION("dynamic") {
             settings::em::fixed_weights = false;
@@ -85,6 +86,7 @@ TEST_CASE("ImageStack::get_protein") {
             std::unique_ptr header = std::make_unique<em::detail::header::MRCHeader>();
             std::unique_ptr header_data = std::make_unique<em::detail::header::MRCData>();
             header_data->cella_x = 6; header_data->cella_y = 6; header_data->cella_z = 2;
+            header_data->nx = 6; header_data->ny = 6; header_data->nz = 2;
             header->set_data(std::move(header_data));
             images.set_header(std::move(header));
 
@@ -110,6 +112,7 @@ TEST_CASE("ImageStack::get_protein") {
             std::unique_ptr header = std::make_unique<em::detail::header::MRCHeader>();
             std::unique_ptr header_data = std::make_unique<em::detail::header::MRCData>();
             header_data->cella_x = 6; header_data->cella_y = 6; header_data->cella_z = 2;
+            header_data->nx = 6; header_data->ny = 6; header_data->nz = 2;
             header->set_data(std::move(header_data));
             images.set_header(std::move(header));
             

--- a/tests/em/image_stack_base.cpp
+++ b/tests/em/image_stack_base.cpp
@@ -1,16 +1,15 @@
-#include "settings/GeneralSettings.h"
-#include "settings/HistogramSettings.h"
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
 #include <hist/intensity_calculator/ICompositeDistanceHistogram.h>
+#include <hist/HistFwd.h>
 #include <em/detail/ImageStackBase.h>
 #include <em/detail/header/data/MRCData.h>
 #include <em/detail/header/MRCHeader.h>
 #include <em/manager/ProteinManager.h>
-#include <hist/HistFwd.h>
 #include <em/ObjectBounds3D.h>
+#include <hydrate/generation/RadialHydration.h>
 #include <data/Molecule.h>
 #include <settings/All.h>
 
@@ -98,6 +97,7 @@ TEST_CASE_METHOD(fixture, "ImageStackBase::images") {
 }
 
 TEST_CASE_METHOD(fixture, "ImageStackBase::get_histogram") {
+    hydrate::RadialHydration::set_noise_generator([] () {return Vector3<double>{0, 0, 0};});
     em::ImageStackBase isb("tests/files/A2M_2020_Q4.ccp4");
     REQUIRE(isb.get_histogram(5)->get_total_counts() == isb.get_protein_manager()->get_histogram(5)->get_total_counts());
 }
@@ -159,21 +159,6 @@ TEST_CASE_METHOD(fixture, "ImageStackBase::size") {
         em::ImageStackBase isb(images);
         REQUIRE(isb.size() == 3);
     }
-}
-
-TEST_CASE_METHOD(fixture, "ImageStackBase::save") {
-    settings::general::verbose = false;
-    io::File file("tests/temp/ImageStackBase.save.pdb");
-    em::ImageStackBase isb(images);
-
-    em::detail::header::MRCData header_data;
-    header_data.cella_x = 1; header_data.cella_y = 1; header_data.cella_z = 1;
-    header_data.nx = 3; header_data.ny = 3; header_data.nz = 3;
-    std::unique_ptr header = std::make_unique<em::detail::header::MRCHeader>(std::move(header_data));
-
-    isb.set_header(std::move(header));
-    isb.save(5, file);
-    REQUIRE(file.exists());
 }
 
 TEST_CASE("ImageStackBase::mean") {

--- a/tests/em/smart_protein_manager.cpp
+++ b/tests/em/smart_protein_manager.cpp
@@ -47,6 +47,7 @@ TEST_CASE_METHOD(fixture, "SmartProteinManager::get_protein", "[files]") {
 }
 
 TEST_CASE_METHOD(fixture, "SmartProteinManager::get_histogram", "[files]") {
+    hydrate::RadialHydration::set_noise_generator([] () {return Vector3<double>{0, 0, 0};});
     CHECK(manager->get_histogram(1)->get_total_counts() == manager->get_protein(1)->get_histogram()->get_total_counts());
 }
 
@@ -62,17 +63,13 @@ TEST_CASE("SmartProteinManager::generate_protein", "[files]") {
     em::ImageStack images("tests/files/A2M_2020_Q4.ccp4");
     for (int alpha = 10; alpha < 24; ++alpha) {
         images.set_protein_manager(std::make_unique<em::managers::SimpleProteinManager>(&images));
-        // hist::ScatteringProfile hist = images.get_histogram(alpha)->debye_transform();
-        auto hist = images.get_histogram(alpha);
+        hist::ScatteringProfile hist = images.get_histogram(alpha)->debye_transform();
         for (unsigned int charge_levels = 10; charge_levels < 100; charge_levels += 10) {
             settings::em::charge_levels = charge_levels;
             images.set_protein_manager(std::make_unique<em::managers::SmartProteinManager>(&images));
             REQUIRE(images.get_protein_manager()->get_charge_levels().size() == charge_levels+1);
             auto hist2 = images.get_histogram(alpha);
-            CHECK(compare_hist(hist->get_aa_counts(), hist2->get_aa_counts()));
-            CHECK(compare_hist(hist->get_aw_counts(), hist2->get_aw_counts()));
-            CHECK(compare_hist(hist->get_ww_counts(), hist2->get_ww_counts()));
-            // REQUIRE(compare_hist(hist, images.get_histogram(alpha)->debye_transform()));
+            REQUIRE(compare_hist(hist, images.get_histogram(alpha)->debye_transform()));
         }
     }
 }
@@ -81,6 +78,9 @@ TEST_CASE("SmartProteinManager::update_protein", "[files]") {
     settings::general::threads = 6;
     settings::em::sample_frequency = 2;
     settings::hist::histogram_manager = settings::hist::HistogramManagerChoice::PartialHistogramManagerMT;
+
+    // ensure hydration shell is deterministic
+    hydrate::RadialHydration::set_noise_generator([] () {return Vector3<double>{0, 0, 0};});
 
     // alpha as the inner loop to check the protein update functionality 
     int alpha_min = 5, alpha_max = 24;


### PR DESCRIPTION
The recent refactorings left the em_fitter in an unreliable state due to a combination of various issues. This PR should fix all of them, making the output almost consistent with that of version 1.1.1. The only difference now is due to PR #143, which changed the grid expansion behaviour from bin indexes to absolute coordinates. 

1. Fixed PDB output for atoms with the `unknown` form factor. Previously, their residue name was too long and broke the strict PDB format. 
2. SmartFitter can now perform only linear fits, like when no hydration is enabled for EM fitting. Previously, the hydration scaling was a dead extra parameter. 
3. The `PartialHistogramManagerMT` was calculating the distances correctly, but mixed up self-correlations with the hydration curve. This led to a very incorrect scaling behaviour when `cw` was being fitted. 
4. The hydration generation was broken for ImageStack proteins, since the dummy atoms were not being expanded at all in the grid due to their `unknown` form factor. This has now been fixed by introducing `EMGrid`, which specifically accounts for this by assigning them a proper radius. 