### PR TITLE
em_fitter: use argument groups

### DIFF
--- a/executable/em_fitter.cpp
+++ b/executable/em_fitter.cpp
@@ -17,28 +17,62 @@ int main(int argc, char const *argv[]) {
     std::ios_base::sync_with_stdio(false);
     settings::fit::verbose = true;
     settings::general::supplementary_plots = false;
+    bool save_settings = false;
 
     io::ExistingFile mfile, mapfile, settings;
     CLI::App app{"Fit an EM map to a SAXS measurement."};
-    app.add_option("input-map", mapfile, "Path to the EM map.")->required()->check(CLI::ExistingFile);
-    app.add_option("input-exp", mfile, "Path to the SAXS measurement.")->required()->check(CLI::ExistingFile);
-    auto p_settings = app.add_option("-s,--settings", settings, "Path to the settings file.")->check(CLI::ExistingFile);
-    app.add_option("--output,-o", settings::general::output, "Path to save the generated figures at.")->default_val("output/em_fitter/");
-    app.add_option_function<std::string>("--unit,-u", [] (const std::string& s) {settings::detail::parse_option("unit", {s});}, "The unit of the q values in the measurement file. Options: A, nm.");
-    app.add_option("--threads,-t", settings::general::threads, "Number of threads to use.")->default_val(settings::general::threads);
-    app.add_option("--qmin", settings::axes::qmin, "Lower limit on used q values from measurement file.");
-    app.add_option("--qmax", settings::axes::qmax, "Upper limit on used q values from measurement file.");
-    app.add_option("--levelmin", settings::em::alpha_levels.min, "Lower limit on the alpha levels to use for the EM map. Note that lowering this limit severely impacts the performance and memory load.");
-    app.add_option("--levelmax", settings::em::alpha_levels.max, "Upper limit on the alpha levels to use for the EM map. Increasing this limit improves the performance.");
-    app.add_option("--charge-levels", settings::em::charge_levels, "Number of charge levels to use for the EM map.");
-    app.add_option("--frequency", settings::em::sample_frequency, "Sampling frequency of the EM map.");
-    app.add_option("--max-iterations", settings::fit::max_iterations, "Maximum number of iterations to perform. This is only approximate.");
-    app.add_flag("--hydrate,!--no-hydrate", settings::em::hydrate, "Generate a hydration shell for the protein before fitting.");
-    app.add_flag("--fixed-weight,!--dynamic-weight", settings::em::fixed_weights, "Use a fixed weight for the fit.");
-    app.add_flag("--verbose,!--quiet", settings::fit::verbose, "Print the progress of the fit to the console.");
-    app.add_flag("--weighted-bins, --!no-weighted-bins", settings::hist::weighted_bins, "Use weighted bins for the distance histograms.")->default_val(settings::hist::weighted_bins)->group("");
-    app.add_flag_callback("--log", [] () {logging::start("em_fitter");}, "Enable logging to a file.");
+    auto input_map = app.add_option("input-map", mapfile, "Path to the EM map.")->check(CLI::ExistingFile);
+    auto input_saxs = app.add_option("input-saxs", mfile, "Path to the SAXS measurement.")->check(CLI::ExistingFile);
+    app.add_option("--output,-o", settings::general::output, "Output folder to write the results to.")->default_val("output/em_fitter/");
     app.add_flag_callback("--licence", [] () {std::cout << constants::licence << std::endl; exit(0);}, "Print the licence.");
+    app.add_flag_callback("-v,--version", [] () {std::cout << constants::version << std::endl; exit(0);}, "Print the AUSAXS version.");
+    app.add_option("--threads,-t", settings::general::threads, "Number of threads to use.")->default_val(settings::general::threads);
+
+    // config subcommands
+    auto sub_config = app.add_subcommand("config", "See and set additional options for the configuration.");
+    auto p_settings = sub_config->add_option("--file,-f", settings, "The configuration file to use.")->check(CLI::ExistingFile);
+    sub_config->add_flag("--save", save_settings, "Save the settings to a file.");
+    sub_config->add_flag_callback("--log", [] () {logging::start("em_fitter");}, "Enable logging to a file.");
+
+    // data subcommands
+    auto sub_data = app.add_subcommand("saxs", "See and set additional options for the SAXS data.");
+    sub_data->add_option("--qmax", settings::axes::qmax, "Upper limit on used q values from the measurement file.")->default_val(settings::axes::qmax);
+    sub_data->add_option("--qmin", settings::axes::qmin, "Lower limit on used q values from the measurement file.")->default_val(settings::axes::qmin);
+    sub_data->add_option_function<std::string>("--unit,-u", [] (const std::string& s) {settings::detail::parse_option("unit", {s});}, "The unit of the q values in the measurement file. Options: A, nm.");
+    sub_data->add_option("--skip", settings::axes::skip, "Number of points to skip in the measurement file.")->default_val(settings::axes::skip);
+    sub_data->add_flag("--rebin", settings::flags::data_rebin, "Rebin the data to increase the information content of each data point.")->default_val(settings::flags::data_rebin);
+
+    // em subcommands
+    auto sub_em = app.add_subcommand("em", "See and set additional options for the EM map.");
+    sub_em->add_option("--levelmin", settings::em::alpha_levels.min, "Lower limit on the alpha levels to use for the EM map. Note that lowering this limit severely impacts the performance and memory load.");
+    sub_em->add_option("--levelmax", settings::em::alpha_levels.max, "Upper limit on the alpha levels to use for the EM map. Increasing this limit improves the performance.");
+    sub_em->add_option("--charge-levels", settings::em::charge_levels, "Number of charge levels to use for the EM map.");
+    sub_em->add_option("--frequency", settings::em::sample_frequency, "Sampling frequency of the EM map.");
+    sub_em->add_flag("--hydrate,!--no-hydrate", settings::em::hydrate, "Generate a hydration shell for the protein before fitting.");
+    sub_em->add_flag("--fixed-weight,!--dynamic-weight", settings::em::fixed_weights, "Use a fixed weight for the fit.");
+
+    // fit subcommands
+    auto sub_fit = app.add_subcommand("fit", "See and set additional options for the fitting process.");
+    sub_fit->add_option("--max-iterations", settings::fit::max_iterations, "Maximum number of iterations to perform. This is only approximate.");
+    sub_fit->add_flag("--verbose,!--quiet", settings::fit::verbose, "Print the progress of the fit to the console.");
+
+    app.final_callback([&] () {
+        // save settings if requested
+        if (save_settings) {
+            settings::write("settings.txt");
+            console::print_info("Settings saved to settings.txt in current directory.");
+            if (!input_map->count() || !input_saxs->count()) { // gracefully exit if no input files are provided
+                exit(0);
+            }
+        }
+
+        // required args (not marked ->required() since that interferes with the help flag for subcommands)
+        if (!input_map->count() || !input_saxs->count()) {
+            std::cout << "Error: Both input_structure and input_measurement are required." << std::endl;
+            exit(1);
+        }
+    });
+
     CLI11_PARSE(app, argc, argv);
 
     console::print_info("Running AUSAXS " + std::string(constants::version));

--- a/executable/saxs_fitter.cpp
+++ b/executable/saxs_fitter.cpp
@@ -30,7 +30,7 @@ int main(int argc, char const *argv[]) {
     CLI::App app{"Generate a new hydration layer and fit the resulting scattering intensity histogram for a given input data file."};
     app.fallthrough();
     auto input_s = app.add_option("input_structure", pdb, "Path to the structure file.")->check(CLI::ExistingFile);
-    app.add_option("input_measurement", mfile, "Path to the measured SAXS data.")->check(CLI::ExistingFile);
+    auto input_m = app.add_option("input_measurement", mfile, "Path to the measured SAXS data.")->check(CLI::ExistingFile);
     app.add_option("--output,-o", settings::general::output, "Output folder to write the results to.")->default_val("output/saxs_fitter/")->group("General options");
     app.add_flag_callback("--licence", [] () {std::cout << constants::licence << std::endl; exit(0);}, "Print the licence.");
     app.add_flag_callback("-v,--version", [] () {std::cout << constants::version << std::endl; exit(0);}, "Print the AUSAXS version.");

--- a/executable/saxs_fitter.cpp
+++ b/executable/saxs_fitter.cpp
@@ -32,7 +32,6 @@ int main(int argc, char const *argv[]) {
     auto input_s = app.add_option("input_structure", pdb, "Path to the structure file.")->check(CLI::ExistingFile);
     app.add_option("input_measurement", mfile, "Path to the measured SAXS data.")->check(CLI::ExistingFile);
     app.add_option("--output,-o", settings::general::output, "Output folder to write the results to.")->default_val("output/saxs_fitter/")->group("General options");
-    // auto p_settings = app.add_option("-s,--settings", settings, "Path to the settings file.")->check(CLI::ExistingFile)->group("General options");
     app.add_flag_callback("--licence", [] () {std::cout << constants::licence << std::endl; exit(0);}, "Print the licence.");
     app.add_flag_callback("-v,--version", [] () {std::cout << constants::version << std::endl; exit(0);}, "Print the AUSAXS version.");
     app.add_flag("!--ignore-unknown-atom", settings::molecule::throw_on_unknown_atom, 

--- a/source/core/settings/CrystalSettings.cpp
+++ b/source/core/settings/CrystalSettings.cpp
@@ -17,13 +17,14 @@ double settings::crystal::reduced::basis_q = 3;
 bool settings::crystal::detail::use_checkpointing = true;
 ausaxs::settings::crystal::MillerGenerationChoice ausaxs::settings::crystal::miller_generation_strategy = ausaxs::settings::crystal::MillerGenerationChoice::All;
 
-namespace ausaxs::settings::io {
-    settings::io::SettingSection crystal_section("Crystal", { 
-        settings::io::create(crystal::h, "h"),
-        settings::io::create(crystal::k, "k"),
-        settings::io::create(crystal::l, "l"),
-        settings::io::create(crystal::max_q, "max_q"),
-        settings::io::create(crystal::grid_expansion, "grid_expansion"),
-        settings::io::create(crystal::reduced::basis_q, "basis_q")
-    });
-}
+//? disabled for now since crystal calculations are not practically used anyway
+// namespace ausaxs::settings::io {
+//     settings::io::SettingSection crystal_section("Crystal", { 
+//         settings::io::create(crystal::h, "h"),
+//         settings::io::create(crystal::k, "k"),
+//         settings::io::create(crystal::l, "l"),
+//         settings::io::create(crystal::max_q, "max_q"),
+//         settings::io::create(crystal::grid_expansion, "grid_expansion"),
+//         settings::io::create(crystal::reduced::basis_q, "basis_q")
+//     });
+// }

--- a/source/core/settings/FitSettings.cpp
+++ b/source/core/settings/FitSettings.cpp
@@ -18,12 +18,12 @@ bool settings::fit::fit_atomic_debye_waller = false;
 bool settings::fit::fit_exv_debye_waller = false;
 
 namespace ausaxs::settings::io {
-    settings::io::SettingSection fit_section("General", {
+    settings::io::SettingSection fit_section("Fit", {
         settings::io::create(fit::verbose, "fit-verbose"),
         settings::io::create(fit::N, "N"),
         settings::io::create(fit::max_iterations, "max_iterations"),
-        settings::io::create(fit::fit_excluded_volume, "fit_excluded_volume"),
-        settings::io::create(fit::fit_solvent_density, "fit_solvent_density"),
-        settings::io::create(fit::fit_hydration, "fit_hydration")
+        settings::io::create(fit::fit_excluded_volume, "excluded_volume"),
+        settings::io::create(fit::fit_solvent_density, "solvent_density"),
+        settings::io::create(fit::fit_hydration, "hydration")
     });
 }

--- a/source/core/settings/MDSettings.cpp
+++ b/source/core/settings/MDSettings.cpp
@@ -19,17 +19,18 @@ std::string settings::md::minimization_sim_location = "lucy";
 std::string settings::md::thermalization_sim_location = "smaug";
 std::string settings::md::production_sim_location = "smaug";
 
-namespace ausaxs::settings::io {
-    settings::io::SettingSection md_section("MD", {
-        settings::io::create(md::gmx_path, {"gmx_exe", "gmx_executable", "gmx"}),
-        settings::io::create(md::buffer_path, {"buffer_path", "buffer"}),
-        settings::io::create(md::water_model, {"water_model", "water"}),
-        settings::io::create(md::force_field, {"force_field", "forcefield", "ff"}),
-        settings::io::create(md::box_type, {"box_type", "boxtype", "box"}),
-        settings::io::create(md::cation, {"cation", "cation_type", "cationtype"}),
-        settings::io::create(md::anion, {"anion", "anion_type", "aniontype"}),
-        settings::io::create(md::minimization_sim_location, "minimization_sim_location"),
-        settings::io::create(md::thermalization_sim_location, "thermalization_sim_location"),
-        settings::io::create(md::production_sim_location, "production_sim_location")
-    });
-}
+//? disabled; MD may be removed in the future
+// namespace ausaxs::settings::io {
+//     settings::io::SettingSection md_section("MD", {
+//         settings::io::create(md::gmx_path, {"gmx_exe", "gmx_executable", "gmx"}),
+//         settings::io::create(md::buffer_path, {"buffer_path", "buffer"}),
+//         settings::io::create(md::water_model, {"water_model", "water"}),
+//         settings::io::create(md::force_field, {"force_field", "forcefield", "ff"}),
+//         settings::io::create(md::box_type, {"box_type", "boxtype", "box"}),
+//         settings::io::create(md::cation, {"cation", "cation_type", "cationtype"}),
+//         settings::io::create(md::anion, {"anion", "anion_type", "aniontype"}),
+//         settings::io::create(md::minimization_sim_location, "minimization_sim_location"),
+//         settings::io::create(md::thermalization_sim_location, "thermalization_sim_location"),
+//         settings::io::create(md::production_sim_location, "production_sim_location")
+//     });
+// }


### PR DESCRIPTION
This PR changes the em_fitter to use argument groups for consistency with the saxs_fitter. 

Both executables now support writing out a template config file containing all supported arguments. 