### PR TITLE
Disable compiling plot.exe for Windows dev builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -59,7 +59,7 @@ jobs:
           mkdir build
           cmake -B build -S . -G "Ninja" \
             -DGUI=ON \
-            -DBUILD_PLOT_EXE=ON \
+            -DBUILD_PLOT_EXE=OFF \
             -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
             -DCMAKE_C_COMPILER=cl \
             -DCMAKE_CXX_COMPILER=cl \


### PR DESCRIPTION
To avoid the intermittent workflow crashes that sometimes occur ([#1](https://github.com/AUSAXS/AUSAXS/actions/runs/16046534343/job/45279146997), [#2](https://github.com/AUSAXS/AUSAXS/actions/runs/15144496041/job/42576752285)) when building the `plot.exe` binary, this PR simply disables this part for dev builds. As we now have a separate workflow for building release candidates, this executable is very unlikely to be needed anyway. 