### PR TITLE
Minor fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: actions/setup-python@v5
 
-      - name: Install dependencies (windows)
+      - name: Install dependencies
         run: |
           vcpkg install curl pkgconf cairo libwebp --triplet x64-windows-static
           choco install ninja

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install dependencies (windows)
+      - name: Install dependencies
         run: |
           vcpkg install curl pkgconf cairo libwebp --triplet x64-windows-static
           choco install ninja

--- a/include/core/hist/intensity_calculator/CompositeDistanceHistogramFFAvgBase.h
+++ b/include/core/hist/intensity_calculator/CompositeDistanceHistogramFFAvgBase.h
@@ -64,7 +64,6 @@ namespace ausaxs::hist {
             virtual ~CompositeDistanceHistogramFFAvgBase() override;
 
             virtual ScatteringProfile debye_transform() const override;
-            virtual SimpleDataset debye_transform(const std::vector<double>& q) const override;
 
             void apply_water_scaling_factor(double k) override;
             void apply_excluded_volume_scaling_factor(double k) override;

--- a/include/core/hist/intensity_calculator/DistanceHistogram.h
+++ b/include/core/hist/intensity_calculator/DistanceHistogram.h
@@ -60,7 +60,7 @@ namespace ausaxs::hist {
              *
              * @param q The q values at which to evaluate the scattering. 
              */
-            virtual SimpleDataset debye_transform(const std::vector<double>& q) const;
+            SimpleDataset debye_transform(const std::vector<double>& q) const;
 
             /**
              * @brief Get the distance axis describing the current histogram.

--- a/source/core/api/sasview.cpp
+++ b/source/core/api/sasview.cpp
@@ -9,7 +9,7 @@
 #include <data/Body.h>
 #include <hist/detail/SimpleExvModel.h>
 #include <hist/intensity_calculator/CompositeDistanceHistogram.h>
-#include <hist/intensity_calculator/CompositeDistanceHistogramFFGridScalableExv.h>
+#include <hist/intensity_calculator/CompositeDistanceHistogramFFGridSurface.h>
 #include <fitter/SmartFitter.h>
 #include <fitter/FitReporter.h>
 #include <constants/Constants.h>
@@ -75,6 +75,7 @@ void iterative_fit_start(
 
 void iterative_fit_step(double* pars, double* return_I, int* return_status) {
     std::cout << "AUSAXS: Starting method \"iterative_fit::step\"." << std::endl;
+    std::cout << "DEBUG VERSION!" << std::endl;
 
     // default state is error since we don't trust the input enough to assume success
     *return_status = 1;
@@ -87,8 +88,8 @@ void iterative_fit_step(double* pars, double* return_I, int* return_status) {
     double c = pars[0];
     double d = pars[1];
     hist->apply_water_scaling_factor(c);
-    static_cast<hist::CompositeDistanceHistogramFFGridScalableExv*>(hist.get())->apply_excluded_volume_scaling_factor(d);
-    
+    static_cast<hist::CompositeDistanceHistogramFFGridSurface*>(hist.get())->apply_excluded_volume_scaling_factor(d);
+
     *return_status = 4;
     auto I = hist->debye_transform(iterative_fit_state.data->x());
 
@@ -123,7 +124,7 @@ void fit_saxs(
 
     // use the multithreaded version of the simple histogram manager
     settings::exv::exv_method = settings::exv::ExvMethod::Simple;
-    settings::fit::fit_excluded_volume = true;
+    settings::fit::fit_excluded_volume = false;
 
     // set qmax as high as it can go
     settings::axes::qmax = 1;
@@ -160,7 +161,7 @@ void fit_saxs(
     fitter::SmartFitter fitter(std::move(data), protein.get_histogram());
     auto res = fitter.fit();
     fitter::FitReporter::report(res.get());
-    fitter::FitReporter::save(res.get(), "ausaxs_fit_result.txt");
+    fitter::FitReporter::save(res.get(), settings::general::output + "ausaxs_fit_result.txt");
 
     res->curves.select_columns({0, 1, 2, 3}).save(
         settings::general::output + "ausaxs.fit", 

--- a/source/core/hist/intensity_calculator/CompositeDistanceHistogramFFAvgBase.cpp
+++ b/source/core/hist/intensity_calculator/CompositeDistanceHistogramFFAvgBase.cpp
@@ -75,11 +75,6 @@ ScatteringProfile CompositeDistanceHistogramFFAvgBase<FormFactorTableType>::deby
 }
 
 template<typename FormFactorTableType>
-SimpleDataset CompositeDistanceHistogramFFAvgBase<FormFactorTableType>::debye_transform(const std::vector<double>&) const {
-    throw except::not_implemented("CompositeDistanceHistogramFFGrid::debye_transform(const std::vector<double>& q) const");
-}
-
-template<typename FormFactorTableType>
 const std::vector<double>& CompositeDistanceHistogramFFAvgBase<FormFactorTableType>::get_counts() const {
     p = std::vector<double>(DistanceHistogram::get_counts().size(), 0);
     auto[aa, aw, ww] = cache_get_distance_profiles();


### PR DESCRIPTION
* Removed unnecessary `(windows)` tag in Windows CI. 
* Updated SasView API interface to avoid triggering warnings and consistently output to the same folder. 
* Removed forgotten `debye_transform(q_vals)` overrides, which led to `not_implemented` errors despite having a fully functional base. 