### PR TITLE
Fix potential segfaults with UNKNOWN form factors

### DIFF
--- a/include/core/form_factor/FormFactor.h
+++ b/include/core/form_factor/FormFactor.h
@@ -116,6 +116,11 @@ namespace ausaxs::form_factor {
                 case form_factor_t::SH:                 return SH;
                 case form_factor_t::OTHER:              return other;
                 case form_factor_t::EXCLUDED_VOLUME:    return excluded_volume;
+                case form_factor_t::UNKNOWN:
+                    throw std::runtime_error(
+                        "form_factor::storage::get_form_factor: Attempted to get the form factor of an UNKNOWN atom.\n"
+                        "This typically occurs when performing species-dependent operations on data without form factor information."
+                    );
                 default: throw std::runtime_error("form_factor::storage::get_form_factor: Invalid form factor type (enum " + std::to_string(static_cast<int>(type)) + ")");
             }
         }

--- a/include/core/hist/detail/CompactCoordinatesFF.h
+++ b/include/core/hist/detail/CompactCoordinatesFF.h
@@ -54,12 +54,26 @@ namespace ausaxs::hist::detail {
 // implementation defined in header to support efficient inlining
 
 template<bool vbw>
+void validate_ff_info(const ausaxs::hist::detail::CompactCoordinatesFF<vbw>& data) {
+    for (unsigned int i = 0; i < data.size(); ++i) {
+        unsigned int ff_type = data.ff_types[i];
+        if (ff_type == static_cast<unsigned int>(ausaxs::form_factor::form_factor_t::UNKNOWN)) {
+            throw std::runtime_error(
+                "CompactCoordinatesFF: Attempted to use an atom with UNKNOWN form factor type.\n"
+                "Form factor information is required for the selected excluded volume model."
+            );
+        }
+    }
+}
+
+template<bool vbw>
 inline ausaxs::hist::detail::CompactCoordinatesFF<vbw>::CompactCoordinatesFF(const data::Body& body) : CompactCoordinates<vbw>(body.size_atom()), ff_types(body.size_atom()) {
     for (unsigned int i = 0; i < this->size(); ++i) {
         const auto& a = body.get_atom(i); 
         this->data[i] = hist::detail::CompactCoordinatesData<vbw>(a.coordinates(), a.weight());
         ff_types[i] = static_cast<int>(a.form_factor_type());
     }
+    validate_ff_info(*this);
 }
 
 template<bool vbw>
@@ -74,6 +88,7 @@ inline ausaxs::hist::detail::CompactCoordinatesFF<vbw>::CompactCoordinatesFF(con
             ff_types[i++] = static_cast<int>(a.form_factor_type());
         }
     }
+    validate_ff_info(*this);
 }
 
 template<bool vbw>
@@ -83,6 +98,7 @@ inline ausaxs::hist::detail::CompactCoordinatesFF<vbw>::CompactCoordinatesFF(con
         this->data[i] = hist::detail::CompactCoordinatesData<vbw>(a.coordinates(), a.weight());
         ff_types[i] = static_cast<int>(a.form_factor_type());
     }
+    validate_ff_info(*this);
 }
 
 template<bool vbw>

--- a/source/core/data/Body.cpp
+++ b/source/core/data/Body.cpp
@@ -44,6 +44,8 @@ auto convert_atom_atomff = [] (const std::vector<data::Atom>& atoms) {
     std::vector<data::AtomFF> atoms_ff;
     atoms_ff.reserve(atoms.size());
     for (auto& a : atoms) {
+        // Assign UNKNOWN form factor when no form factor information is available
+        // This will trigger an error if the form factor is actually used in calculations
         atoms_ff.emplace_back(a, form_factor::form_factor_t::UNKNOWN);
     }
     return atoms_ff;

--- a/tests/feature/api/unknown_form_factor.cpp
+++ b/tests/feature/api/unknown_form_factor.cpp
@@ -1,0 +1,76 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include <data/Molecule.h>
+#include <data/Body.h>
+#include <data/atoms/Atom.h>
+#include <settings/All.h>
+#include <hist/intensity_calculator/ICompositeDistanceHistogram.h>
+
+using namespace ausaxs;
+
+TEST_CASE("test_unknown_form_factor: UNKNOWN form factors with Fraser excluded volume model") {
+    // Set settings BEFORE creating the molecule so the histogram manager uses Fraser method
+    settings::fit::fit_hydration = true;
+    settings::fit::fit_excluded_volume = true;
+    settings::exv::exv_method = settings::exv::ExvMethod::Fraser;
+    
+    // Create atoms without form factor information (like molecule_from_arrays does)
+    // Using data::Atom creates atoms without form factor information, which will be converted
+    // to UNKNOWN form factors when added to a Body
+    std::vector<data::Atom> atoms;
+    atoms.emplace_back(Vector3<double>{0.0, 0.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{1.0, 0.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{0.0, 1.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{0.0, 0.0, 1.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{-1.0, 0.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{0.0, -1.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{0.0, 0.0, -1.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{1.0, 1.0, 1.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{-1.0, -1.0, -1.0}, 1.0);
+    
+    REQUIRE(atoms.size() == 9);
+    
+    // Create molecule from atoms (this will convert them to AtomFF with UNKNOWN form factors)
+    auto molecule = data::Molecule({data::Body{atoms}});
+    REQUIRE(molecule.size_atom() == 9);
+    
+    // Verify that atoms have UNKNOWN form factors (when no form factor info is available)
+    auto& body = molecule.get_bodies()[0];
+    auto& atoms_ff = body.get_atoms();
+    CHECK(atoms_ff[0].form_factor_type() == form_factor::form_factor_t::UNKNOWN);
+    
+    // This should throw an informative error when trying to use UNKNOWN form factors with Fraser
+    REQUIRE_THROWS_WITH([&]() {
+        auto hist = molecule.get_histogram();
+        auto I = hist->debye_transform();
+    }(), Catch::Matchers::ContainsSubstring("UNKNOWN form factor"));
+}
+
+TEST_CASE("test_unknown_form_factor_simple: UNKNOWN form factors with Simple excluded volume model") {
+    // Set Simple ExV method - this should work fine with UNKNOWN form factors
+    settings::exv::exv_method = settings::exv::ExvMethod::Simple;
+    
+    // Create atoms without form factor information
+    std::vector<data::Atom> atoms;
+    atoms.emplace_back(Vector3<double>{0.0, 0.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{1.0, 0.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{0.0, 1.0, 0.0}, 1.0);
+    atoms.emplace_back(Vector3<double>{0.0, 0.0, 1.0}, 1.0);
+    
+    // Create molecule
+    auto molecule = data::Molecule({data::Body{atoms}});
+    REQUIRE(molecule.size_atom() == 4);
+    
+    // Verify atoms have UNKNOWN form factors
+    auto& body = molecule.get_bodies()[0];
+    auto& atoms_ff = body.get_atoms();
+    CHECK(atoms_ff[0].form_factor_type() == form_factor::form_factor_t::UNKNOWN);
+    
+    // This should work fine with Simple ExV model (doesn't need form factor info)
+    REQUIRE_NOTHROW([&]() {
+        auto hist = molecule.get_histogram();
+        auto I = hist->debye_transform();
+        REQUIRE(I.size() > 0);
+    }());
+}

--- a/tests/feature/api/unknown_form_factor_c_api.cpp
+++ b/tests/feature/api/unknown_form_factor_c_api.cpp
@@ -1,0 +1,62 @@
+// Test case to reproduce the segfault with UNKNOWN form factors and Fraser ExV model
+// This uses the C API directly, similar to how Python bindings work
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <api/api_pyausaxs.h>
+#include <api/api_settings.h>
+
+TEST_CASE("test_unknown_form_factor_c_api: UNKNOWN form factors with Fraser exv model via C API") {
+    // Create atoms without form factor information (like molecule_from_arrays does)
+    double x[] = {0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 0.0, 1.0, -1.0};
+    double y[] = {0.0, 0.0, 1.0, 0.0, 0.0, -1.0, 0.0, 1.0, -1.0};
+    double z[] = {0.0, 0.0, 0.0, 1.0, 0.0, 0.0, -1.0, 1.0, -1.0};
+    double w[] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0};
+    int n_atoms = 9;
+    
+    int status = 0;
+    
+    // Create molecule from arrays
+    int mol_id = molecule_from_arrays(x, y, z, w, n_atoms, &status);
+    REQUIRE(status == 0);
+    REQUIRE(mol_id >= 0);
+    
+    // Set problematic settings via C API
+    set_exv_settings("Fraser", &status);
+    REQUIRE(status == 0);
+    
+    set_fit_settings(10, 100, true, true, true, false, false, &status);
+    REQUIRE(status == 0);
+    
+    // This should trigger the crash if the bug exists
+    double *aa, *aw, *ww;
+    int n_bins;
+    double delta_r;
+    int hist_id = molecule_distance_histogram(mol_id, &aa, &aw, &ww, &n_bins, &delta_r, &status);
+    
+    if (status != 0) {
+        char* error_msg = nullptr;
+        int error_status = 0;
+        get_last_error_msg(&error_msg, &error_status);
+        FAIL("Failed to get histogram: " << (error_msg ? error_msg : "Unknown error"));
+    }
+    
+    REQUIRE(hist_id >= 0);
+    REQUIRE(n_bins > 0);
+    
+    // Try debye transform - this should fail with an informative error about UNKNOWN form factors
+    double *q, *I;
+    int n_points;
+    molecule_debye(mol_id, &q, &I, &n_points, &status);
+    
+    // We expect this to fail because the Fraser model requires form factor information
+    REQUIRE(status != 0);
+    
+    char* error_msg = nullptr;
+    int error_status = 0;
+    get_last_error_msg(&error_msg, &error_status);
+    REQUIRE(error_msg != nullptr);
+    
+    std::string error_str(error_msg);
+    CHECK(error_str.find("UNKNOWN form factor") != std::string::npos);
+}


### PR DESCRIPTION
This PR adds additional safeguards surrounding form factor-dependent code, to avoid memory corruption and potential segfaults when dealing with `UNKNOWN` atoms. 

This is especially critical since they are somewhat easy to trigger through the python wrapper, and easily leads to memory corruption as the out-of-bounds checking is disabled in production code. 