### PR TITLE
Add options to use system-provided libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ option(DLIB "Download and use the dlib minimizers" ON)
 option(BUILD_PLOT_EXE "Compile the plotting utility as an executable for the current platform" OFF)
 option(CONSTEXPR_TABLES "Generate lookup tables at compile-time" OFF)
 set(ARCH "native" CACHE STRING "Target architecture. Default: native")
+option(USE_SYSTEM_GCEM "Use system provided GCEM" OFF)
+option(USE_SYSTEM_BACKWARD "Use system provided backward" OFF)
+option(USE_SYSTEM_CLI11 "Use system provided CLI11" OFF)
+option(USE_SYSTEM_THREADPOOL "Use system provided thread-pool" OFF)
+option(USE_SYSTEM_CATCH "Use system provided Catch" OFF)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -110,20 +115,44 @@ if (DLIB)
 	add_compile_definitions("DLIB_AVAILABLE")
 endif()
 
-FetchContent_Declare(
-	backward
-	GIT_REPOSITORY https://github.com/bombela/backward-cpp
-)
+if(USE_SYSTEM_BACKWARD)
+	find_package(Backward REQUIRED)
+else()
+	FetchContent_Declare(
+		backward
+		GIT_REPOSITORY https://github.com/bombela/backward-cpp
+	)
+	FetchContent_MakeAvailable(Backward)
+endif()
 
-FetchContent_Declare(
-	thread_pool
-	GIT_REPOSITORY https://github.com/bshoshany/thread-pool
-)
+if(USE_SYSTEM_THREADPOOL)
+	include(CheckIncludeFileCXX)
 
-FetchContent_Declare(
-	gcem
-	GIT_REPOSITORY https://github.com/klytje/gcem
-)
+	check_include_file_cxx(
+		BS_thread_pool.hpp
+		BS_THREAD_POOL_FOUND
+	)
+
+	if (NOT BS_THREAD_POOL_FOUND)
+		message(FATAL_ERROR "BS.thread_pool headers not found")
+	endif()
+else()
+	FetchContent_Declare(
+		thread_pool
+		GIT_REPOSITORY https://github.com/bshoshany/thread-pool
+	)
+	FetchContent_MakeAvailable(thread_pool)
+endif()
+
+if(USE_SYSTEM_GCEM)
+	find_package(gcem REQUIRED)
+else()
+	FetchContent_Declare(
+		gcem
+		GIT_REPOSITORY https://github.com/klytje/gcem
+	)
+	FetchContent_MakeAvailable(GCEM)
+endif()
 
 set_property(
     DIRECTORY
@@ -131,7 +160,6 @@ set_property(
 )
 unset(compile_options)
 
-FetchContent_MakeAvailable(thread_pool GCEM backward)
 include_directories(${thread_pool_SOURCE_DIR}/include ${gcem_SOURCE_DIR}/include ${backward_SOURCE_DIR})
 
 ############################################

--- a/executable/CMakeLists.txt
+++ b/executable/CMakeLists.txt
@@ -1,10 +1,14 @@
-FetchContent_Declare(
-	CLI11
-	GIT_REPOSITORY https://github.com/CLIUtils/CLI11
-	GIT_TAG 792d89286788acac125e0487f8dbde88035f7422
-	GIT_PROGRESS TRUE
-)
-FetchContent_MakeAvailable(CLI11)
+if(USE_SYSTEM_CLI11)
+	find_package(CLI11 REQUIRED)
+else()
+	FetchContent_Declare(
+		CLI11
+		GIT_REPOSITORY https://github.com/CLIUtils/CLI11
+		GIT_TAG 792d89286788acac125e0487f8dbde88035f7422
+		GIT_PROGRESS TRUE
+	)
+	FetchContent_MakeAvailable(CLI11)
+endif()
 
 # helper function to attach post-build copy of plotting scripts to an executable target.
 function(add_plot_scripts_to_target _target)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,14 +11,18 @@ endif()
 
 set_directory_properties(PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
-include(FetchContent)
-FetchContent_Declare(
-	Catch2
-	GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-	GIT_TAG 914aeecfe23b1e16af6ea675a4fb5dbd5a5b8d0a
-	GIT_PROGRESS TRUE
-)
-FetchContent_MakeAvailable(Catch2)
+if(USE_SYSTEM_CATCH)
+	find_package(Catch2 REQUIRED)
+else()
+	include(FetchContent)
+	FetchContent_Declare(
+		Catch2
+		GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+		GIT_TAG 914aeecfe23b1e16af6ea675a4fb5dbd5a5b8d0a
+		GIT_PROGRESS TRUE
+	)
+	FetchContent_MakeAvailable(Catch2)
+endif()
 
 # make the tests available through CTest
 list(APPEND CMAKE_MODULE_PATH ${catch2_SOURCE_DIR}/extras)


### PR DESCRIPTION
As discussed recently via email - when packaging AUSAXS for Debian, the build system has no access to the internet, cmake is explicitly configured to not use external package registries, and tools like `FetchContent` are disabled. The distribution is supposed to be self-hosting, so all dependencies need to already be packaged, and then dependent packages build against them, etc.

This patch adds CMake options to use system-provided libraries rather than downloading them for libraries used by the CLI and tests. This work will need to be extended to optional libraries (dlib) and libraries used by the GUI; I've not done that as we're a long way from trying to package the GUI at this stage, so it would be untested.

The default behaviour remains the same; for packaging, the options can be given to the cmake configure step:

``` 
-DUSE_SYSTEM_GCEM=ON 
-DUSE_SYSTEM_BACKWARD=ON          
-DUSE_SYSTEM_CLI11=ON 
-DUSE_SYSTEM_THREADPOOL=ON 
-DUSE_SYSTEM_CATCH=ON
```