### PR TITLE
Molecule atom & water iterators

### DIFF
--- a/include/core/data/Molecule.h
+++ b/include/core/data/Molecule.h
@@ -196,6 +196,14 @@ namespace ausaxs::data {
 			[[nodiscard]] ausaxs::MoleculeAtomRange<const Body> iterate_atoms() const;
 
 			/**
+			 * @brief Iterate over all water molecules across all bodies without copying.
+			 *        Bodies carrying no waters are silently skipped.
+			 *        Complexity: O(1) to obtain; O(n) to traverse.
+			 */
+			[[nodiscard]] ausaxs::MoleculeWaterRange<Body> iterate_waters();
+			[[nodiscard]] ausaxs::MoleculeWaterRange<const Body> iterate_waters() const;
+
+			/**
 			 * @brief Get a copy of all water molecules from the underlying bodies.
 			 *        Complexity: O(n)
 			 */

--- a/include/core/data/Molecule.h
+++ b/include/core/data/Molecule.h
@@ -5,6 +5,7 @@
 
 #include <hist/HistFwd.h>
 #include <data/DataFwd.h>
+#include <data/detail/AtomIterator.h>
 #include <data/atoms/AtomFF.h>
 #include <data/atoms/Water.h>
 #include <data/symmetry/MoleculeSymmetryFacade.h>
@@ -186,6 +187,13 @@ namespace ausaxs::data {
 			 *        Complexity: O(n)
 			 */
 			[[nodiscard]] std::vector<data::AtomFF> get_atoms() const;
+
+			/**
+			 * @brief Iterate over all atoms across all bodies without copying.
+			 *        Complexity: O(1) to obtain; O(n) to traverse.
+			 */
+			[[nodiscard]] ausaxs::MoleculeAtomRange<Body> iterate_atoms();
+			[[nodiscard]] ausaxs::MoleculeAtomRange<const Body> iterate_atoms() const;
 
 			/**
 			 * @brief Get a copy of all water molecules from the underlying bodies.

--- a/include/core/data/detail/AtomIterator.h
+++ b/include/core/data/detail/AtomIterator.h
@@ -19,14 +19,14 @@ namespace ausaxs {
         using ref_body_t  = std::conditional_t<std::is_const_v<TBody>, const body_t, body_t>;
         using body_iter_t = std::conditional_t<std::is_const_v<TBody>, typename std::vector<body_t>::const_iterator, typename std::vector<body_t>::iterator>;
         using atom_vec_t  = std::remove_reference_t<decltype(std::declval<ref_body_t&>().get_atoms())>;
-        using atom_iter_t = typename atom_vec_t::iterator;
+        using atom_iter_t = std::conditional_t<std::is_const_v<atom_vec_t>, typename atom_vec_t::const_iterator, typename atom_vec_t::iterator>;
 
     public:
         using iterator_category = std::forward_iterator_tag;
         using difference_type   = std::ptrdiff_t;
-        using value_type        = typename atom_vec_t::value_type;
-        using pointer           = typename atom_vec_t::pointer;
-        using reference         = typename atom_vec_t::reference;
+        using value_type        = typename std::remove_cv_t<atom_vec_t>::value_type;
+        using pointer           = std::conditional_t<std::is_const_v<atom_vec_t>, const value_type*, value_type*>;
+        using reference         = std::conditional_t<std::is_const_v<atom_vec_t>, const value_type&, value_type&>;
 
         MoleculeAtomIterator() = default;
 

--- a/include/core/data/detail/AtomIterator.h
+++ b/include/core/data/detail/AtomIterator.h
@@ -85,4 +85,96 @@ namespace ausaxs {
         iterator begin() const { return {bodies_.begin(), bodies_.end()}; }
         iterator end()   const { return {bodies_.end(),   bodies_.end()}; }
     };
+
+    /**
+     * @brief Forward iterator that traverses all water molecules across all bodies of a molecule in order,
+     *        skipping bodies that carry no hydration layer.
+     *        Use TBody=Body for a mutable iterator, TBody=const Body for a read-only iterator.
+     */
+    template<typename TBody>
+    class MoleculeWaterIterator {
+        using body_t      = std::remove_cv_t<TBody>;
+        using ref_body_t  = std::conditional_t<std::is_const_v<TBody>, const body_t, body_t>;
+        using body_iter_t = std::conditional_t<std::is_const_v<TBody>,
+                                typename std::vector<body_t>::const_iterator,
+                                typename std::vector<body_t>::iterator>;
+        // get_waters() returns optional<reference_wrapper<vector<Water>>> or the const variant
+        using opt_waters_t  = std::remove_reference_t<decltype(std::declval<ref_body_t&>().get_waters())>;
+        // Extract the vector type via reference_wrapper::get()
+        using water_vec_t   = std::remove_reference_t<decltype(std::declval<opt_waters_t>()->get())>;
+        using water_iter_t  = std::conditional_t<std::is_const_v<water_vec_t>,
+                                  typename water_vec_t::const_iterator,
+                                  typename water_vec_t::iterator>;
+
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = typename std::remove_cv_t<water_vec_t>::value_type;
+        using pointer           = std::conditional_t<std::is_const_v<water_vec_t>, const value_type*, value_type*>;
+        using reference         = std::conditional_t<std::is_const_v<water_vec_t>, const value_type&, value_type&>;
+
+        MoleculeWaterIterator() = default;
+
+        MoleculeWaterIterator(body_iter_t first, body_iter_t last) : body_cur_(first), body_end_(last) {
+            advance_to_valid_body();
+        }
+
+        reference operator*()  const { return *water_cur_; }
+        pointer   operator->() const { return &*water_cur_; }
+
+        MoleculeWaterIterator& operator++() {
+            ++water_cur_;
+            skip_empty();
+            return *this;
+        }
+
+        MoleculeWaterIterator operator++(int) { auto tmp = *this; ++(*this); return tmp; }
+
+        bool operator==(const MoleculeWaterIterator& rhs) const {
+            if (body_cur_ == body_end_ && rhs.body_cur_ == rhs.body_end_) { return true;  }
+            if (body_cur_ == body_end_ || rhs.body_cur_ == rhs.body_end_) { return false; }
+            return body_cur_ == rhs.body_cur_ && water_cur_ == rhs.water_cur_;
+        }
+
+        bool operator!=(const MoleculeWaterIterator& rhs) const { return !(*this == rhs); }
+
+    private:
+        body_iter_t body_cur_{}, body_end_{};
+        water_iter_t water_cur_{}, water_end_{};
+
+        // Advance body_cur_ (starting from current position) until a body with non-empty waters
+        // is found, or body_end_ is reached. Sets water_cur_/water_end_ on success.
+        void advance_to_valid_body() {
+            while (body_cur_ != body_end_) {
+                auto w = body_cur_->get_waters();
+                if (w.has_value() && !w->get().empty()) {
+                    water_cur_ = w->get().begin();
+                    water_end_ = w->get().end();
+                    return;
+                }
+                ++body_cur_;
+            }
+        }
+
+        void skip_empty() {
+            while (body_cur_ != body_end_ && water_cur_ == water_end_) {
+                ++body_cur_;
+                advance_to_valid_body();
+            }
+        }
+    };
+
+    template<typename TBody>
+    class MoleculeWaterRange {
+        using body_t    = std::remove_cv_t<TBody>;
+        using vec_ref_t = std::conditional_t<std::is_const_v<TBody>, const std::vector<body_t>&, std::vector<body_t>&>;
+        vec_ref_t bodies_;
+    public:
+        using iterator = MoleculeWaterIterator<TBody>;
+
+        explicit MoleculeWaterRange(vec_ref_t bodies) : bodies_(bodies) {}
+
+        iterator begin() const { return {bodies_.begin(), bodies_.end()}; }
+        iterator end()   const { return {bodies_.end(),   bodies_.end()}; }
+    };
 }

--- a/include/core/data/detail/AtomIterator.h
+++ b/include/core/data/detail/AtomIterator.h
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+namespace ausaxs {
+    /**
+     * @brief Forward iterator that traverses all atoms across all bodies of a molecule in order.
+     *        TBody must be complete at instantiation; a forward declaration suffices to name the type.
+     *        Use TBody=Body for a mutable iterator, TBody=const Body for a read-only iterator.
+     */
+    template<typename TBody>
+    class MoleculeAtomIterator {
+        using body_t      = std::remove_cv_t<TBody>;
+        using ref_body_t  = std::conditional_t<std::is_const_v<TBody>, const body_t, body_t>;
+        using body_iter_t = std::conditional_t<std::is_const_v<TBody>, typename std::vector<body_t>::const_iterator, typename std::vector<body_t>::iterator>;
+        using atom_vec_t  = std::remove_reference_t<decltype(std::declval<ref_body_t&>().get_atoms())>;
+        using atom_iter_t = typename atom_vec_t::iterator;
+
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = typename atom_vec_t::value_type;
+        using pointer           = typename atom_vec_t::pointer;
+        using reference         = typename atom_vec_t::reference;
+
+        MoleculeAtomIterator() = default;
+
+        MoleculeAtomIterator(body_iter_t first, body_iter_t last) : body_cur_(first), body_end_(last) {
+            if (body_cur_ != body_end_) {
+                atom_cur_ = body_cur_->get_atoms().begin();
+                atom_end_ = body_cur_->get_atoms().end();
+                skip_empty();
+            }
+        }
+
+        reference operator*()  const { return *atom_cur_; }
+        pointer   operator->() const { return &*atom_cur_; }
+
+        MoleculeAtomIterator& operator++() {
+            ++atom_cur_;
+            skip_empty();
+            return *this;
+        }
+
+        MoleculeAtomIterator operator++(int) { auto tmp = *this; ++(*this); return tmp; }
+
+        bool operator==(const MoleculeAtomIterator& rhs) const {
+            if (body_cur_ == body_end_ && rhs.body_cur_ == rhs.body_end_) { return true;  }
+            if (body_cur_ == body_end_ || rhs.body_cur_ == rhs.body_end_) { return false; }
+            return body_cur_ == rhs.body_cur_ && atom_cur_ == rhs.atom_cur_;
+        }
+
+        bool operator!=(const MoleculeAtomIterator& rhs) const { return !(*this == rhs); }
+
+    private:
+        body_iter_t body_cur_{}, body_end_{};
+        atom_iter_t atom_cur_{}, atom_end_{};
+
+        void skip_empty() {
+            while (body_cur_ != body_end_ && atom_cur_ == atom_end_) {
+                ++body_cur_;
+                if (body_cur_ != body_end_) {
+                    atom_cur_ = body_cur_->get_atoms().begin();
+                    atom_end_ = body_cur_->get_atoms().end();
+                }
+            }
+        }
+    };
+
+    template<typename TBody>
+    class MoleculeAtomRange {
+        using body_t    = std::remove_cv_t<TBody>;
+        using vec_ref_t = std::conditional_t<std::is_const_v<TBody>, const std::vector<body_t>&, std::vector<body_t>&>;
+        vec_ref_t bodies_;
+    public:
+        using iterator = MoleculeAtomIterator<TBody>;
+
+        explicit MoleculeAtomRange(vec_ref_t bodies) : bodies_(bodies) {}
+
+        iterator begin() const { return {bodies_.begin(), bodies_.end()}; }
+        iterator end()   const { return {bodies_.end(),   bodies_.end()}; }
+    };
+}

--- a/source/core/data/Molecule.cpp
+++ b/source/core/data/Molecule.cpp
@@ -178,6 +178,14 @@ std::vector<AtomFF> Molecule::get_atoms() const {
     return atoms;
 }
 
+MoleculeAtomRange<Body> Molecule::iterate_atoms() {
+    return MoleculeAtomRange<Body>(bodies);
+}
+
+MoleculeAtomRange<const Body> Molecule::iterate_atoms() const {
+    return MoleculeAtomRange<const Body>(bodies);
+}
+
 Vector3<double> Molecule::get_cm(bool include_water) const {
     Vector3<double> cm{0, 0, 0};
     double M = 0; // total mass

--- a/source/core/data/Molecule.cpp
+++ b/source/core/data/Molecule.cpp
@@ -113,10 +113,8 @@ double Molecule::get_Rg(bool include_waters) const {
     double Rg = 0;
 
     // Rg is defined as the RMS average distance of each _electron_ from the center of mass, so multiply each atom by its effective charge
-    for (auto& body : get_bodies()) {
-        for (auto& a : body.get_atoms()) {
-            Rg += cm.distance2(a.coordinates())*a.weight();
-        }
+    for (auto& a : iterate_atoms()) {
+        Rg += cm.distance2(a.coordinates())*a.weight();
     }
 
     // return the RMS
@@ -165,16 +163,11 @@ observer_ptr<grid::Grid> Molecule::create_grid() const {
 }
 
 std::vector<AtomFF> Molecule::get_atoms() const {
-    std::size_t N = std::accumulate(bodies.begin(), bodies.end(), std::size_t{0}, [] (std::size_t sum, const Body& body) {return sum + body.size_atom();});
-    std::vector<AtomFF> atoms(N);
-    int n = 0; // current index
-    for (const auto& body : bodies) {
-        for (const auto& a : body.get_atoms()) {
-            atoms[n] = a;
-            n++;
-        }
+    std::vector<AtomFF> atoms;
+    atoms.reserve(size_atom());
+    for (const auto& a : this->iterate_atoms()) {
+        atoms.push_back(a);
     }
-    if (n != static_cast<int>(N)) [[unlikely]] {throw except::size_error("Molecule::atoms: incorrect number of atoms. This should never happen.");}
     return atoms;
 }
 

--- a/source/core/data/Molecule.cpp
+++ b/source/core/data/Molecule.cpp
@@ -166,7 +166,7 @@ std::vector<AtomFF> Molecule::get_atoms() const {
     std::vector<AtomFF> atoms;
     atoms.reserve(size_atom());
     for (const auto& a : this->iterate_atoms()) {
-        atoms.push_back(a);
+        atoms.emplace_back(a);
     }
     return atoms;
 }
@@ -179,43 +179,39 @@ MoleculeAtomRange<const Body> Molecule::iterate_atoms() const {
     return MoleculeAtomRange<const Body>(bodies);
 }
 
+MoleculeWaterRange<Body> Molecule::iterate_waters() {
+    return MoleculeWaterRange<Body>(bodies);
+}
+
+MoleculeWaterRange<const Body> Molecule::iterate_waters() const {
+    return MoleculeWaterRange<const Body>(bodies);
+}
+
 Vector3<double> Molecule::get_cm(bool include_water) const {
     Vector3<double> cm{0, 0, 0};
     double M = 0; // total mass
 
-    // iterate through all constituent bodies
-    for (const auto& body : bodies) {
-        // iterate through their molecule atoms
-        std::for_each(body.get_atoms().begin(), body.get_atoms().end(), [&M, &cm] (const auto& atom) {
-            double m = constants::mass::get_mass(atom.form_factor_type());
-            M += m;
-            cm += atom.coordinates()*m;
-        });
-        if (!include_water) {continue;}
-
-        // iterate through their hydration atoms
-        auto w = body.get_waters();
-        if (!w.has_value()) {continue;}
-        std::for_each(w.value().get().begin(), w.value().get().end(), [&M, &cm] (const auto& water) {
+    for (const auto& atom : this->iterate_atoms()) {
+        double m = constants::mass::get_mass(atom.form_factor_type());
+        M += m;
+        cm += atom.coordinates()*m;
+    }
+    if (include_water) {
+        for (const auto& water : this->iterate_waters()) {
             double m = constants::mass::get_mass(water.form_factor_type());
             M += m;
             cm += water.coords*m;
-        });
+        }
     }
     assert(M != 0 && "Molecule::get_cm: Division by zero. The molecule has no atoms.");
     return cm/M;
 }
 
 std::vector<Water> Molecule::get_waters() const {
-    std::vector<Water> waters(size_water());
-    int n = 0; // current index
-    for (const auto& body : bodies) {
-        auto w = body.get_waters();
-        if (!w.has_value()) {continue;}
-        for (const auto& a : w.value().get()) {
-            waters[n] = a;
-            n++;
-        }
+    std::vector<Water> waters;
+    waters.reserve(size_water());
+    for (const auto& w : this->iterate_waters()) {
+        waters.emplace_back(w);
     }
     return waters;
 }

--- a/source/core/grid/exv/ExvVolume.cpp
+++ b/source/core/grid/exv/ExvVolume.cpp
@@ -25,10 +25,8 @@ double ausaxs::grid::exv::get_volume_exv(observer_ptr<const data::Molecule> m, d
 
         // we extract the volumes from the form factors since they have a better interface than the raw volume sets
         auto ff_table = form_factor::detail::ExvFormFactorSet(*form_factor::ExvTableManager::get_current_exv_table());
-        for (const auto& body : m->get_bodies()) {
-            volume += std::accumulate(body.get_atoms().begin(), body.get_atoms().end(), 0.0, [&ff_table] (double sum, const data::AtomFF& atom) {
-                return sum + ff_table.get(atom.form_factor_type()).evaluate(0);
-            });
+        for (const auto& atom : m->iterate_atoms()) {
+            volume += ff_table.get(atom.form_factor_type()).evaluate(0);
         }
         return volume / constants::charge::density::water;
     };

--- a/tests/feature/data/molecule.cpp
+++ b/tests/feature/data/molecule.cpp
@@ -768,3 +768,31 @@ TEST_CASE("Molecule: implicit hydrogens") {
         CHECK(atoms[8].form_factor_type() == form_factor::form_factor_t::N);
     }
 }
+
+TEST_CASE("Molecule::iterate_atoms") {
+    SECTION("simple") {
+        std::vector<AtomFF> atoms = {
+            AtomFF({-1, -1, -1}, form_factor::form_factor_t::C), AtomFF({-1, 1, -1}, form_factor::form_factor_t::NH2),
+            AtomFF({ 1, -1, -1}, form_factor::form_factor_t::H), AtomFF({ 1, 1, -1}, form_factor::form_factor_t::SH),
+            AtomFF({-1, -1,  1}, form_factor::form_factor_t::CH3), AtomFF({-1, 1,  1}, form_factor::form_factor_t::CH2),
+            AtomFF({ 1, -1,  1}, form_factor::form_factor_t::N), AtomFF({ 1, 1,  1}, form_factor::form_factor_t::O)
+        };
+        Molecule protein({Body{atoms}});
+
+        size_t count = 0;
+        for (const auto& atom : protein.iterate_atoms()) {
+            CHECK(atom == atoms[count++]);
+        }
+        REQUIRE(count == atoms.size());
+    }
+
+    SECTION("real system") {
+        Molecule molecule("tests/files/2epe.pdb");
+        auto atoms = molecule.get_atoms();
+        size_t count = 0;
+        for (const auto& atom : molecule.iterate_atoms()) {
+            CHECK(atom == atoms[count++]);
+        }
+        REQUIRE(count == atoms.size());
+    }
+}

--- a/tests/feature/data/molecule.cpp
+++ b/tests/feature/data/molecule.cpp
@@ -863,9 +863,11 @@ TEST_CASE("Molecule::iterate_waters") {
 
         // assign to individual bodies
         int stride = waters.size() / molecule.size_body();
-        for (size_t i = 0; i < molecule.size_body(); i++) {
+        for (size_t i = 0; i < molecule.size_body()-1; i++) {
             molecule.get_body(i).set_hydration(hydrate::Hydration::create(std::vector<Water>(waters.begin() + i*stride, waters.begin() + (i+1)*stride)));
         }
+        // assign remainder to the last body
+        molecule.get_bodies().back().set_hydration(hydrate::Hydration::create(std::vector<Water>(waters.begin() + (molecule.size_body()-1)*stride, waters.end())));
 
         size_t count = 0;
         for (const auto& water : molecule.iterate_waters()) {

--- a/tests/feature/data/molecule.cpp
+++ b/tests/feature/data/molecule.cpp
@@ -14,6 +14,8 @@
 #include <hist/histogram_manager/HistogramManager.h>
 #include <hist/intensity_calculator/CompositeDistanceHistogram.h>
 #include <hist/intensity_calculator/ExactDebyeCalculator.h>
+#include <io/pdb/PDBStructure.h>
+#include <rigidbody/BodySplitter.h>
 
 #include <vector>
 #include <string>
@@ -692,7 +694,6 @@ TEST_CASE_METHOD(fixture, "Molecule::signal_modified_hydration_layer") {
     REQUIRE(manager->is_modified_hydration() == true);
 }
 
-#include <io/pdb/PDBStructure.h>
 TEST_CASE("Molecule: implicit hydrogens") {
     auto generate_molecule = [] () {
         std::vector<io::pdb::PDBAtom> a = {
@@ -770,6 +771,16 @@ TEST_CASE("Molecule: implicit hydrogens") {
 }
 
 TEST_CASE("Molecule::iterate_atoms") {
+    SECTION("empty") {
+        Molecule molecule;
+        size_t count = 0;
+        for (const auto& atom : molecule.iterate_atoms()) {
+            (void)atom; // to silence unused variable warning
+            ++count;
+        }
+        REQUIRE(count == 0);
+    }
+
     SECTION("simple") {
         std::vector<AtomFF> atoms = {
             AtomFF({-1, -1, -1}, form_factor::form_factor_t::C), AtomFF({-1, 1, -1}, form_factor::form_factor_t::NH2),
@@ -777,10 +788,10 @@ TEST_CASE("Molecule::iterate_atoms") {
             AtomFF({-1, -1,  1}, form_factor::form_factor_t::CH3), AtomFF({-1, 1,  1}, form_factor::form_factor_t::CH2),
             AtomFF({ 1, -1,  1}, form_factor::form_factor_t::N), AtomFF({ 1, 1,  1}, form_factor::form_factor_t::O)
         };
-        Molecule protein({Body{atoms}});
+        Molecule molecule({Body{atoms}});
 
         size_t count = 0;
-        for (const auto& atom : protein.iterate_atoms()) {
+        for (const auto& atom : molecule.iterate_atoms()) {
             CHECK(atom == atoms[count++]);
         }
         REQUIRE(count == atoms.size());
@@ -794,5 +805,72 @@ TEST_CASE("Molecule::iterate_atoms") {
             CHECK(atom == atoms[count++]);
         }
         REQUIRE(count == atoms.size());
+    }
+
+    SECTION("multiple bodies") {
+        auto molecule = rigidbody::BodySplitter::split("tests/files/LAR1-2.pdb", {1, 15, 35, 55, 75, 95});
+        auto atoms = molecule.get_atoms();
+        size_t count = 0;
+        for (const auto& atom : molecule.iterate_atoms()) {
+            CHECK(atom == atoms[count++]);
+        }
+        REQUIRE(count == atoms.size());
+    }
+}
+
+TEST_CASE("Molecule::iterate_waters") {
+    SECTION("empty") {
+        Molecule molecule;
+        size_t count = 0;
+        for (const auto& water : molecule.iterate_waters()) {
+            (void)water; // to silence unused variable warning
+            ++count;
+        }
+        REQUIRE(count == 0);
+    }
+
+    SECTION("simple") {
+        std::vector<Water> waters = {
+            Water(Vector3<double>(-1, -1, -1)), Water(Vector3<double>(-1, 1, -1)),
+            Water(Vector3<double>(1, -1, -1)), Water(Vector3<double>(1, 1, -1)),
+            Water(Vector3<double>(-1, -1, 1)), Water(Vector3<double>(-1, 1, 1)),
+            Water(Vector3<double>(1, -1, 1)), Water(Vector3<double>(1, 1, 1))
+        };
+        Molecule molecule(std::vector{Body{{}, waters}});
+
+        size_t count = 0;
+        for (const auto& water : molecule.iterate_waters()) {
+            CHECK(water == waters[count++]);
+        }
+        REQUIRE(count == waters.size());
+    }
+
+    SECTION("real system") {
+        Molecule molecule("tests/files/2epe.pdb");
+        molecule.generate_new_hydration();
+        auto waters = molecule.get_waters();
+        size_t count = 0;
+        for (const auto& water : molecule.iterate_waters()) {
+            CHECK(water == waters[count++]);
+        }
+        REQUIRE(count == waters.size());
+    }
+
+    SECTION("multiple bodies") {
+        auto molecule = rigidbody::BodySplitter::split("tests/files/LAR1-2.pdb", {1, 15, 35, 55, 75, 95});
+        molecule.generate_new_hydration();
+        auto waters = molecule.get_waters();
+
+        // assign to individual bodies
+        int stride = waters.size() / molecule.size_body();
+        for (size_t i = 0; i < molecule.size_body(); i++) {
+            molecule.get_body(i).set_hydration(hydrate::Hydration::create(std::vector<Water>(waters.begin() + i*stride, waters.begin() + (i+1)*stride)));
+        }
+
+        size_t count = 0;
+        for (const auto& water : molecule.iterate_waters()) {
+            CHECK(water == waters[count++]);
+        }
+        REQUIRE(count == waters.size());
     }
 }

--- a/tests/feature/hist/composite_distance_histogram.cpp
+++ b/tests/feature/hist/composite_distance_histogram.cpp
@@ -286,11 +286,9 @@ TEST_CASE("CompositeDistanceHistogram::debye_transform", "[files]") {
         SECTION("real data (" + std::string(data) + ")") {
             data::Molecule protein("tests/files/" + std::string(data) + ".pdb");
             protein.clear_hydration();
-            for (auto& body : protein.get_bodies()) {
-                for (auto& atom : body.get_atoms()) {
-                    atom.form_factor_type() = form_factor::form_factor_t::C;
-                    atom.weight() = 1;
-                }
+            for (auto& atom : protein.iterate_atoms()) {
+                atom.form_factor_type() = form_factor::form_factor_t::C;
+                atom.weight() = 1;
             }
 
             auto exact = exact_aa_carbon(protein);

--- a/tests/feature/hist/hist_test_helper.h
+++ b/tests/feature/hist/hist_test_helper.h
@@ -73,10 +73,10 @@ bool compare_hist_approx(T1 p1, T2 p2, double abs = 1e-6, double rel = 1e-3) {
 template<typename T>
 void set_unity_charge(T& protein) {
     // set the weights to 1 so we can analytically determine the result
+    for (auto& atom : protein.iterate_atoms()) {
+        atom.weight() = 1;
+    }
     for (auto& body : protein.get_bodies()) {
-        for (auto& atom : body.get_atoms()) {
-            atom.weight() = 1;
-        }
         auto w = body.get_waters();
         if (!w.has_value()) {continue;}
         for (auto& water : w->get()) {

--- a/tests/feature/hist/hist_test_helper.h
+++ b/tests/feature/hist/hist_test_helper.h
@@ -76,12 +76,8 @@ void set_unity_charge(T& protein) {
     for (auto& atom : protein.iterate_atoms()) {
         atom.weight() = 1;
     }
-    for (auto& body : protein.get_bodies()) {
-        auto w = body.get_waters();
-        if (!w.has_value()) {continue;}
-        for (auto& water : w->get()) {
-            water.weight() = 1;
-        }
+    for (auto& water : protein.iterate_waters()) {
+        water.weight() = 1;
     }
 }
 


### PR DESCRIPTION
This PR makes it easier to iterate over all atoms and waters contained in a given molecule. Specifically, the pattern:

```
for (auto& b : molecule.get_bodies()) {
    for (auto& a : b.get_atoms()) {
        [work]
    }
}
```
may now be simplified to a single loop:
```
for (auto& a : molecule.iterate_atoms()) {
    [work]
}
```