### PR TITLE
Fix broken wide-angle calculations

### DIFF
--- a/source/core/hist/intensity_calculator/DistanceHistogram.cpp
+++ b/source/core/hist/intensity_calculator/DistanceHistogram.cpp
@@ -69,12 +69,12 @@ ScatteringProfile DistanceHistogram::debye_transform() const {
 
 SimpleDataset DistanceHistogram::debye_transform(const std::vector<double>& q) const {
     // if the q values are within the default range, we can just interpolate them for better performance
-    if (constants::axes::q_axis.min < q.front() && q.back() < constants::axes::q_axis.max) {
+    if (constants::axes::q_axis.min <= q.front() && q.back() <= constants::axes::q_axis.max) {
         return debye_transform().as_dataset().interpolate(q);
     }
     static table::DebyeTableManager sinc_table_extended;
     sinc_table_extended.set_q_axis(q);
-    sinc_table.set_d_axis(this->d_axis);
+    sinc_table_extended.set_d_axis(this->d_axis);
     const auto& sinqd_table = sinc_table_extended.get_sinc_table();
 
     // calculate the scattering intensity based on the Debye equation

--- a/tests/feature/hist/distance_histogram.cpp
+++ b/tests/feature/hist/distance_histogram.cpp
@@ -1,4 +1,5 @@
 #include <catch2/generators/catch_generators.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/catch_test_macros.hpp>
 
 #include <dataset/SimpleDataset.h>
@@ -47,31 +48,89 @@ TEST_CASE("DistanceHistogram: check relative errors") {
     settings::general::verbose = false;
     settings::molecule::implicit_hydrogens = false;
     settings::hist::weighted_bins = true;
+    settings::exv::exv_method = settings::exv::ExvMethod::None;
+    settings::axes::qmax = constants::axes::q_axis.max;
 
     // only use small-ish files here
     auto file = GENERATE(
         "2epe",
         "6lyz",
-        "LAR1-2",
-        "diamond",
-        "c60"
+        "LAR1-2"
     );
 
-    SECTION(file) {
-        auto protein = data::Molecule("tests/files/" + std::string(file) + ".pdb");
-        protein.clear_hydration();
-        auto hist = protein.get_histogram();
+    INFO("Testing file: " << file);
+    auto protein = data::Molecule("tests/files/" + std::string(file) + ".pdb");
+    protein.clear_hydration();
+    auto hist = protein.get_histogram();
+    auto I_exact = hist::exact_debye_transform(protein, constants::axes::q_axis.as_vector());
+
+    {   // default q-range
         auto I_estimated = hist->debye_transform();
-        auto I_exact = hist::exact_debye_transform(protein, constants::axes::q_axis.as_vector());
-
-        plots::PlotDataset plot;
-        plot.plot(I_estimated.as_dataset(), plots::PlotOptions({{"color", style::color::black}, {"logx", true}, {"logy", true}}));
-        plot.plot(SimpleDataset(std::vector<double>(constants::axes::q_vals.begin(), constants::axes::q_vals.end()), I_exact), plots::PlotOptions({{"color", style::color::red}}));
-        plot.save(settings::general::output + "tests/hist/distance_histogram/relative_errors.png");
-
+        REQUIRE(I_estimated.size() == I_exact.size());
         for (unsigned int i = 0; i < I_estimated.size(); ++i) {
             auto rel_error = std::abs(I_estimated[i] - I_exact[i]) / I_exact[i];
-            REQUIRE(rel_error < 0.01);
+            REQUIRE(rel_error < 0.02);
         }
+    }
+
+    {   // custom q-range: debye_transform(q) must give the same result as debye_transform()
+        auto q_vec = constants::axes::q_axis.as_vector();
+        auto I_default = hist->debye_transform();
+        auto I_custom  = hist->debye_transform(q_vec);
+        REQUIRE(I_custom.size() == I_default.size());
+        for (unsigned int i = 0; i < I_custom.size(); ++i) {
+            REQUIRE_THAT(I_custom.y(i), Catch::Matchers::WithinRelMatcher(I_default[i], 1e-6));
+        }
+    }
+}
+
+TEST_CASE("DistanceHistogram: crystals with fine binning") {
+    settings::general::verbose = false;
+    settings::molecule::implicit_hydrogens = false;
+    settings::hist::weighted_bins = true;
+    settings::exv::exv_method = settings::exv::ExvMethod::None;
+    settings::axes::qmax = constants::axes::q_axis.max;
+    settings::axes::bin_width = 0.05;
+
+    auto file = GENERATE(
+        "c60",
+        "diamond"
+    );
+
+    auto protein = data::Molecule("tests/files/" + std::string(file) + ".pdb");
+    protein.clear_hydration();
+    auto hist = protein.get_histogram();
+    auto I_exact = hist::exact_debye_transform(protein, constants::axes::q_axis.as_vector());
+
+    auto I_estimated = hist->debye_transform();
+    REQUIRE(I_estimated.size() == I_exact.size());
+    double I0 = I_exact[0]; // forward scattering as normalization
+    for (unsigned int i = 0; i < I_estimated.size(); ++i) {
+        auto abs_err = std::abs(I_estimated[i] - I_exact[i]) / I0;
+        REQUIRE(abs_err < 0.01);
+    }
+}
+
+TEST_CASE("DistanceHistogram: extended q-range") {
+    settings::general::verbose = false;
+    settings::molecule::implicit_hydrogens = false;
+    settings::hist::weighted_bins = true;
+    settings::exv::exv_method = settings::exv::ExvMethod::None;
+
+    auto protein = data::Molecule("tests/files/2epe.pdb");
+    protein.clear_hydration();
+    auto hist = protein.get_histogram();
+
+    std::vector<double> q(200);
+    for (unsigned int i = 0; i < q.size(); ++i) {
+        q[i] = (i+1)*(10./q.size()); // q values from 0.05 to 10 Å⁻¹
+    }
+    auto I_dynamic = hist->debye_transform(q);
+    auto I_exact   = hist::exact_debye_transform(protein, q);
+
+    REQUIRE(I_dynamic.size() == q.size());
+    for (unsigned int i = 0; i < I_dynamic.size(); ++i) {
+        auto rel_error = std::abs(I_dynamic.y(i) - I_exact[i]) / I_exact[i];
+        REQUIRE(rel_error < 0.03);
     }
 }


### PR DESCRIPTION
PR #275 introduced a bug into the wide-angle scattering calculations where the weighted distances were not being applied to the `sinc` calculations, leading to severe errors. This bug has now been corrected, and a test added to catch it in the future. 