### PR TITLE
Fixed missing `on_change` trigger for `SettingRef` changes

### DIFF
--- a/include/core/settings/SettingRef.h
+++ b/include/core/settings/SettingRef.h
@@ -86,6 +86,7 @@ namespace ausaxs::settings::io::detail {
             // Delegate to SettingRef<T>
             SettingRef<T> ref(settingref.value, names);
             ref.set(values);
+            if (settingref.on_change) {settingref.on_change(settingref.value);}
         }
 
         std::string get() const override {


### PR DESCRIPTION
Fixed missing `on_change` trigger when SettingRef::set was being used. This was preventing changes to settings via the `pyAUSAXS` wrapper from propagating correctly, specifically meaning non-default bin widths could not be used despite the program claiming they were. 