### PR TITLE
Added rigidbody script validator

### DIFF
--- a/include/api/api/api_pyausaxs.h
+++ b/include/api/api/api_pyausaxs.h
@@ -8,6 +8,7 @@
 #include <api/pyausaxs/api_form_factor.h>
 #include <api/pyausaxs/api_iterative_fit.h>
 #include <api/pyausaxs/api_molecule.h>
+#include <api/pyausaxs/api_output.h>
 #include <api/pyausaxs/api_pdb.h>
 #include <api/pyausaxs/api_rigidbody.h>
 #include <api/pyausaxs/api_settings.h>

--- a/include/api/api/api_pyausaxs.h
+++ b/include/api/api/api_pyausaxs.h
@@ -9,4 +9,5 @@
 #include <api/pyausaxs/api_iterative_fit.h>
 #include <api/pyausaxs/api_molecule.h>
 #include <api/pyausaxs/api_pdb.h>
+#include <api/pyausaxs/api_rigidbody.h>
 #include <api/pyausaxs/api_settings.h>

--- a/include/api/api/pyausaxs/api_output.h
+++ b/include/api/api/pyausaxs/api_output.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#pragma once
+
+#include <api/api_helper.h>
+
+extern "C" API typedef void (*ausaxs_output_cb)(const char* str, int len);
+
+extern "C" API void set_output_callback(ausaxs_output_cb cb);
+
+extern "C" API void reset_output_callback();

--- a/include/api/api/pyausaxs/api_rigidbody.h
+++ b/include/api/api/pyausaxs/api_rigidbody.h
@@ -15,8 +15,9 @@ extern "C" API void rigidbody_validate(
     int* status
 );
 
-extern "C" API void rigidbody_run(
+extern "C" API int rigidbody_run(
     int rigidbody_id,
+    double** q, double** I, double** I_err, double** I_interp, int* n_points,
     int* status
 );
 

--- a/include/api/api/pyausaxs/api_rigidbody.h
+++ b/include/api/api/pyausaxs/api_rigidbody.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#pragma once
+
+#include <api/api_helper.h>
+
+extern "C" API int rigidbody_load_script(
+    const char* script,
+    int* status
+);
+
+extern "C" API int rigidbody_validate(
+    int rigidbody_id,
+    int* status
+);
+
+extern "C" API int rigidbody_run(
+    int rigidbody_id,
+    int* status
+);

--- a/include/api/api/pyausaxs/api_rigidbody.h
+++ b/include/api/api/pyausaxs/api_rigidbody.h
@@ -10,12 +10,25 @@ extern "C" API int rigidbody_load_script(
     int* status
 );
 
-extern "C" API int rigidbody_validate(
+extern "C" API void rigidbody_validate(
     int rigidbody_id,
     int* status
 );
 
-extern "C" API int rigidbody_run(
+extern "C" API void rigidbody_run(
     int rigidbody_id,
+    int* status
+);
+
+extern "C" API void rigidbody_get_valid_elements(
+    const char*** elements,
+    int* size,
+    int* status
+);
+
+extern "C" API void rigidbody_get_valid_arguments(
+    const char* element_name,
+    const char*** arguments,
+    int* size,
     int* status
 );

--- a/include/rigidbody/rigidbody/detail/RigidbodyInternalFwd.h
+++ b/include/rigidbody/rigidbody/detail/RigidbodyInternalFwd.h
@@ -25,6 +25,6 @@ namespace ausaxs::rigidbody {
 
     namespace constraints {
         struct ConstraintManager;
-        class IDistanceConstraint;
+        struct IDistanceConstraint;
     }
 }

--- a/include/rigidbody/rigidbody/sequencer/Sequencer.h
+++ b/include/rigidbody/rigidbody/sequencer/Sequencer.h
@@ -26,6 +26,12 @@ namespace ausaxs::rigidbody::sequencer {
             std::shared_ptr<fitter::FitResult> execute() override;
 
             /**
+             * @brief Disabled. Sequencer must always be invoked via execute() to ensure proper setup.
+             *        Calling run() directly skips rigidbody and controller initialization.
+             */
+            void run() override;
+
+            /**
              * @brief Expose the setup element for configuration.
              */
             SetupElement& setup();

--- a/include/rigidbody/rigidbody/sequencer/detail/AdditionalElements.h
+++ b/include/rigidbody/rigidbody/sequencer/detail/AdditionalElements.h
@@ -6,8 +6,20 @@
 #include <rigidbody/sequencer/Sequencer.h>
 
 namespace ausaxs::rigidbody::sequencer::detail {
-    struct SeedElement {static void _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);};
-    struct LoopEndElement {static void _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);};
-    struct OverlapStrengthElement {static void _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);};
-    struct LogElement {static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);};
+    struct SeedElement {
+        static void _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
+        static std::vector<std::string> _valid_arguments();
+    };
+    struct LoopEndElement {
+        static void _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
+        static std::vector<std::string> _valid_arguments();
+    };
+    struct OverlapStrengthElement {
+        static void _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
+        static std::vector<std::string> _valid_arguments();
+    };
+    struct LogElement {
+        static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
+        static std::vector<std::string> _valid_arguments();
+    };
 }

--- a/include/rigidbody/rigidbody/sequencer/detail/ArgumentHelper.h
+++ b/include/rigidbody/rigidbody/sequencer/detail/ArgumentHelper.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace ausaxs::rigidbody::sequencer::detail {
+    template<class Args>
+    std::vector<std::string> get_arg_names(const std::unordered_map<Args, std::vector<std::string>>& args_map) {
+        std::vector<std::string> args; 
+        args.reserve(args_map.size() * 2);
+        for (const auto& [_, arg_names] : args_map) {
+            for (const auto& name : arg_names) {
+                args.emplace_back(name);
+            }
+        }
+        return args;
+    }
+}

--- a/include/rigidbody/rigidbody/sequencer/detail/SequenceParser.h
+++ b/include/rigidbody/rigidbody/sequencer/detail/SequenceParser.h
@@ -10,9 +10,11 @@ namespace ausaxs::rigidbody::sequencer {
         public:
             SequenceParser() = default;
 
-            std::unique_ptr<Sequencer> parse(const io::ExistingFile& config);
+            std::unique_ptr<Sequencer> parse_file(const io::ExistingFile& config);
+            std::unique_ptr<Sequencer> parse_text(const std::string& script);
 
         private:
+            std::unique_ptr<Sequencer> parse(std::istream& in, const std::string& config_folder = "");
             std::vector<observer_ptr<LoopElement>> loop_stack;
     };
 }

--- a/include/rigidbody/rigidbody/sequencer/detail/ValidElements.h
+++ b/include/rigidbody/rigidbody/sequencer/detail/ValidElements.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace ausaxs::rigidbody::sequencer {
+    enum class ElementType {
+        AutomaticConstraint,
+        BodySelect,
+        Constraint,
+        Copy,
+        EveryNStep,
+        LoadElement,
+        Log,
+        LoopBegin,
+        LoopEnd,
+        Message,
+        OnImprovement,
+        OptimizeStep,
+        OutputFolder,
+        OverlapStrength,
+        Parameter,
+        RelativeHydration,
+        Save,
+        Seed,
+        SymmetryElement,
+        Transform,
+        COUNT
+    };
+
+    static std::vector<std::string> valid_elements();
+    static std::vector<std::string> valid_arguments(ElementType type);
+    ElementType get_type(std::string_view line);
+}

--- a/include/rigidbody/rigidbody/sequencer/detail/ValidElements.h
+++ b/include/rigidbody/rigidbody/sequencer/detail/ValidElements.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-namespace ausaxs::rigidbody::sequencer {
+namespace ausaxs::rigidbody::sequencer::detail {
     enum class ElementType {
         AutomaticConstraint,
         BodySelect,
@@ -31,7 +31,7 @@ namespace ausaxs::rigidbody::sequencer {
         COUNT
     };
 
-    static std::vector<std::string> valid_elements();
-    static std::vector<std::string> valid_arguments(ElementType type);
+    std::vector<std::string> valid_elements();
+    std::vector<std::string> valid_arguments(ElementType type);
     ElementType get_type(std::string_view line);
 }

--- a/include/rigidbody/rigidbody/sequencer/elements/BodySelectElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/BodySelectElement.h
@@ -18,6 +18,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/ConvertSymmetryElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/ConvertSymmetryElement.h
@@ -21,6 +21,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
     };
 }

--- a/include/rigidbody/rigidbody/sequencer/elements/EveryNStepElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/EveryNStepElement.h
@@ -15,6 +15,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/LoopElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/LoopElement.h
@@ -93,6 +93,7 @@ namespace ausaxs::rigidbody::sequencer {
             static unsigned int _get_total_iterations();
             static void _add_total_iterations(unsigned int n);
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         protected: 

--- a/include/rigidbody/rigidbody/sequencer/elements/MessageElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/MessageElement.h
@@ -18,6 +18,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/OnImprovementElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/OnImprovementElement.h
@@ -21,6 +21,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/OptimizeStepElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/OptimizeStepElement.h
@@ -25,6 +25,7 @@ namespace ausaxs::rigidbody::sequencer {
              */
             bool was_accepted() const {return step_accepted;}
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/ParameterElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/ParameterElement.h
@@ -27,6 +27,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             observer_ptr<rigidbody::parameter::ParameterGenerationStrategy> get_parameter_strategy() const;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/SaveElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/SaveElement.h
@@ -18,6 +18,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/TransformElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/TransformElement.h
@@ -18,6 +18,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/AutoConstraintsElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/AutoConstraintsElement.h
@@ -17,6 +17,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private: 

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/ConstraintElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/ConstraintElement.h
@@ -20,6 +20,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static void _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
     };
 }

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/CopyBodyElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/CopyBodyElement.h
@@ -29,6 +29,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/LoadElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/LoadElement.h
@@ -36,6 +36,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/LoadExistingElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/LoadExistingElement.h
@@ -26,6 +26,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/OutputFolderElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/OutputFolderElement.h
@@ -27,6 +27,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private: 

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/RelativeHydrationElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/RelativeHydrationElement.h
@@ -24,6 +24,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/include/rigidbody/rigidbody/sequencer/elements/setup/SymmetryElement.h
+++ b/include/rigidbody/rigidbody/sequencer/elements/setup/SymmetryElement.h
@@ -20,6 +20,7 @@ namespace ausaxs::rigidbody::sequencer {
 
             void run() override;
 
+            static std::vector<std::string> _valid_arguments();
             static std::unique_ptr<GenericElement> _parse(observer_ptr<LoopElement> owner, ParsedArgs&& args);
 
         private:

--- a/source/api/CMakeLists.txt
+++ b/source/api/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(ausaxs_api OBJECT
     "pyausaxs/api_iterative_fit.cpp"
     "pyausaxs/api_molecule.cpp"
     "pyausaxs/api_pdb.cpp"
+    "pyausaxs/api_rigidbody.cpp"
     "pyausaxs/api_settings.cpp"
 )
 

--- a/source/api/CMakeLists.txt
+++ b/source/api/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(ausaxs_api OBJECT
     "pyausaxs/api_io.cpp"
     "pyausaxs/api_iterative_fit.cpp"
     "pyausaxs/api_molecule.cpp"
+    "pyausaxs/api_output.cpp"
     "pyausaxs/api_pdb.cpp"
     "pyausaxs/api_rigidbody.cpp"
     "pyausaxs/api_settings.cpp"

--- a/source/api/cli/cli_rigidbody.cpp
+++ b/source/api/cli/cli_rigidbody.cpp
@@ -123,7 +123,7 @@ int cli_rigidbody(int argc, char const *argv[]) {
 
         // check if pdb is a config script
         if (constants::filetypes::config.check(pdb)) {
-            auto res = rigidbody::sequencer::SequenceParser().parse(pdb)->execute();
+            auto res = rigidbody::sequencer::SequenceParser().parse_file(pdb)->execute();
             fitter::FitReporter::report(res.get());
             fitter::FitReporter::save(res.get(), settings::general::output + "fit.txt");
             res->curves.save(settings::general::output + "ausaxs.fit", "chi2=" + std::to_string(res->fval/res->dof) + " dof=" + std::to_string(res->dof));

--- a/source/api/pyausaxs/api_output.cpp
+++ b/source/api/pyausaxs/api_output.cpp
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#include <api/pyausaxs/api_output.h>
+
+#include <memory>
+#include <iostream>
+#include <streambuf>
+#include <string>
+
+namespace {
+    /**
+     * A std::streambuf that forwards output to a C callback, flushing on each
+     * newline and on sync() (called by std::endl and std::flush).
+     */
+    class CCallbackStreamBuf : public std::streambuf {
+        public:
+            explicit CCallbackStreamBuf(ausaxs_output_cb cb, std::streambuf* original)
+                : cb_(cb), original_(original) {}
+
+            std::streambuf* original() const { return original_; }
+
+        protected:
+            int overflow(int c) override {
+                if (c != EOF) {
+                    char ch = static_cast<char>(c);
+                    xsputn(&ch, 1);
+                }
+                return c;
+            }
+
+            std::streamsize xsputn(const char* s, std::streamsize n) override {
+                for (std::streamsize i = 0; i < n; ++i) {
+                    buf_ += s[i];
+                    if (s[i] == '\n') {
+                        cb_(buf_.c_str(), static_cast<int>(buf_.size()));
+                        buf_.clear();
+                    }
+                }
+                return n;
+            }
+
+            int sync() override {
+                if (!buf_.empty()) {
+                    cb_(buf_.c_str(), static_cast<int>(buf_.size()));
+                    buf_.clear();
+                }
+                return 0;
+            }
+
+        private:
+            ausaxs_output_cb cb_;
+            std::string buf_;
+            std::streambuf* original_;
+    };
+
+    std::unique_ptr<CCallbackStreamBuf> g_current = nullptr;
+}
+
+void set_output_callback(ausaxs_output_cb cb) {
+    // Always restore any previously installed callback first.
+    if (g_current) {
+        std::cout.rdbuf(g_current->original());
+        g_current = nullptr;
+    }
+    if (cb) {
+        g_current = std::make_unique<CCallbackStreamBuf>(cb, std::cout.rdbuf());
+        std::cout.rdbuf(g_current.get());
+    }
+}
+
+void reset_output_callback() {
+    set_output_callback(nullptr);
+}

--- a/source/api/pyausaxs/api_rigidbody.cpp
+++ b/source/api/pyausaxs/api_rigidbody.cpp
@@ -37,7 +37,7 @@ void rigidbody_run(
     auto script_obj = api::ObjectStorage::get_object<_rigidbody_script_obj>(rigidbody_id);
     if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return;}
     auto sequencer = rigidbody::sequencer::SequenceParser().parse_text(script_obj->script);
-    sequencer->run();
+    sequencer->execute();
 }, status);}
 
 void rigidbody_get_valid_elements(

--- a/source/api/pyausaxs/api_rigidbody.cpp
+++ b/source/api/pyausaxs/api_rigidbody.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#include <api/pyausaxs/api_pdb.h>
+#include <api/ObjectStorage.h>
+#include <rigidbody/sequencer/detail/SequenceParser.h>
+
+using namespace ausaxs;
+
+struct _rigidbody_script_obj {
+    std::string script;
+};
+extern "C" API int rigidbody_load_script(
+    const char* script,
+    int* status
+) {return execute_with_catch([&]() {
+    _rigidbody_script_obj data;
+    data.script = script;
+    int data_id = api::ObjectStorage::register_object(std::move(data));
+    return data_id;
+}, status);}
+
+extern "C" API int rigidbody_validate(
+    int rigidbody_id,
+    int* status
+) {return execute_with_catch([&]() {
+    auto script_obj = api::ObjectStorage::get_object<_rigidbody_script_obj>(rigidbody_id);
+    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return -1;}
+    rigidbody::sequencer::SequenceParser().parse_text(script_obj->script);
+    return 0;
+}, status);}
+
+extern "C" API int rigidbody_run(
+    int rigidbody_id,
+    int* status
+) {return execute_with_catch([&]() {
+    auto script_obj = api::ObjectStorage::get_object<_rigidbody_script_obj>(rigidbody_id);
+    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return -1;}
+    auto sequencer = rigidbody::sequencer::SequenceParser().parse_text(script_obj->script);
+    sequencer->run();
+    return 0;
+}, status);}

--- a/source/api/pyausaxs/api_rigidbody.cpp
+++ b/source/api/pyausaxs/api_rigidbody.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 // Author: Kristian Lytje
 
-#include <api/pyausaxs/api_pdb.h>
+#include <api/pyausaxs/api_rigidbody.h>
 #include <api/ObjectStorage.h>
 #include <rigidbody/sequencer/detail/SequenceParser.h>
 #include <rigidbody/sequencer/detail/ValidElements.h>

--- a/source/api/pyausaxs/api_rigidbody.cpp
+++ b/source/api/pyausaxs/api_rigidbody.cpp
@@ -4,13 +4,14 @@
 #include <api/pyausaxs/api_pdb.h>
 #include <api/ObjectStorage.h>
 #include <rigidbody/sequencer/detail/SequenceParser.h>
+#include <rigidbody/sequencer/detail/ValidElements.h>
 
 using namespace ausaxs;
 
 struct _rigidbody_script_obj {
     std::string script;
 };
-extern "C" API int rigidbody_load_script(
+int rigidbody_load_script(
     const char* script,
     int* status
 ) {return execute_with_catch([&]() {
@@ -20,23 +21,55 @@ extern "C" API int rigidbody_load_script(
     return data_id;
 }, status);}
 
-extern "C" API int rigidbody_validate(
+void rigidbody_validate(
     int rigidbody_id,
     int* status
 ) {return execute_with_catch([&]() {
     auto script_obj = api::ObjectStorage::get_object<_rigidbody_script_obj>(rigidbody_id);
-    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return -1;}
+    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return;}
     rigidbody::sequencer::SequenceParser().parse_text(script_obj->script);
-    return 0;
 }, status);}
 
-extern "C" API int rigidbody_run(
+void rigidbody_run(
     int rigidbody_id,
     int* status
 ) {return execute_with_catch([&]() {
     auto script_obj = api::ObjectStorage::get_object<_rigidbody_script_obj>(rigidbody_id);
-    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return -1;}
+    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return;}
     auto sequencer = rigidbody::sequencer::SequenceParser().parse_text(script_obj->script);
     sequencer->run();
-    return 0;
+}, status);}
+
+void rigidbody_get_valid_elements(
+    const char*** elements,
+    int* size,
+    int* status
+) {execute_with_catch([&]() {
+    static std::vector<std::string> valid_elements = rigidbody::sequencer::detail::valid_elements();
+    static std::vector<const char*> valid_elements_cstr = [&] () {
+        std::vector<const char*> cstrs;
+        for (const auto& elem : valid_elements) {cstrs.push_back(elem.c_str());}
+        return cstrs;
+    }();
+    *elements = valid_elements_cstr.data();
+    *size = valid_elements.size();
+}, status);}
+
+void rigidbody_get_valid_arguments(
+    const char* element_name,
+    const char*** arguments,
+    int* size,
+    int* status
+) {execute_with_catch([&]() {
+    auto type = rigidbody::sequencer::detail::get_type(element_name);
+    static std::unordered_map<rigidbody::sequencer::detail::ElementType, std::vector<std::string>> valid_arguments_map;
+    static std::unordered_map<rigidbody::sequencer::detail::ElementType, std::vector<const char*>> valid_arguments_cstr_map;
+    if (!valid_arguments_map.contains(type)) {
+        valid_arguments_map[type] = rigidbody::sequencer::detail::valid_arguments(type);
+        std::vector<const char*> cstrs;
+        for (const auto& arg : valid_arguments_map[type]) {cstrs.push_back(arg.c_str());}
+        valid_arguments_cstr_map[type] = cstrs;
+    }
+    *arguments = valid_arguments_cstr_map[type].data();
+    *size = valid_arguments_map[type].size();
 }, status);}

--- a/source/api/pyausaxs/api_rigidbody.cpp
+++ b/source/api/pyausaxs/api_rigidbody.cpp
@@ -3,8 +3,11 @@
 
 #include <api/pyausaxs/api_rigidbody.h>
 #include <api/ObjectStorage.h>
+#include <rigidbody/Rigidbody.h>
 #include <rigidbody/sequencer/detail/SequenceParser.h>
 #include <rigidbody/sequencer/detail/ValidElements.h>
+#include <rigidbody/constraints/ConstrainedFitter.h>
+#include <hist/intensity_calculator/ICompositeDistanceHistogram.h>
 
 using namespace ausaxs;
 
@@ -30,14 +33,33 @@ void rigidbody_validate(
     rigidbody::sequencer::SequenceParser().parse_text(script_obj->script);
 }, status);}
 
-void rigidbody_run(
+struct _data_get_data_obj {
+    std::vector<double> q, I, I_err, I_inter;
+};
+int rigidbody_run(
     int rigidbody_id,
+    double** q, double** I, double** I_err, double** I_interp, int* n_points,
     int* status
 ) {return execute_with_catch([&]() {
     auto script_obj = api::ObjectStorage::get_object<_rigidbody_script_obj>(rigidbody_id);
-    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return;}
+    if (!script_obj) {ErrorMessage::last_error = "Invalid rigidbody script id: \"" + std::to_string(rigidbody_id) + "\""; return -1;}
     auto sequencer = rigidbody::sequencer::SequenceParser().parse_text(script_obj->script);
     sequencer->execute();
+
+    auto data = sequencer->_get_controller()->get_fitter()->fit()->curves.select_columns({0, 1, 2, 3});
+    _data_get_data_obj data_obj;
+    data_obj.q = data.col(0);
+    data_obj.I = data.col(1);
+    data_obj.I_err = data.col(2);
+    data_obj.I_inter = data.col(3);
+    int data_id = api::ObjectStorage::register_object(std::move(data_obj));
+    auto ref = api::ObjectStorage::get_object<_data_get_data_obj>(data_id);
+    *q = ref->q.data();
+    *I = ref->I.data();
+    *I_err = ref->I_err.data();
+    *I_interp = ref->I_inter.data();
+    *n_points = static_cast<int>(ref->q.size());
+    return data_id;
 }, status);}
 
 void rigidbody_get_valid_elements(

--- a/source/rigidbody/CMakeLists.txt
+++ b/source/rigidbody/CMakeLists.txt
@@ -47,8 +47,9 @@ add_library(ausaxs_rigidbody OBJECT
 
 	"sequencer/Sequencer.cpp"
 	"sequencer/detail/AdditionalElements.cpp"
-	"sequencer/detail/SequenceParser.cpp"
 	"sequencer/detail/ParsedArgs.cpp"
+	"sequencer/detail/SequenceParser.cpp"
+	"sequencer/detail/ValidElements.cpp"
 	"sequencer/elements/BodySelectElement.cpp"
 	"sequencer/elements/ConstraintIteratorElementCallback.cpp"
 	"sequencer/elements/ConvertSymmetryElement.cpp"

--- a/source/rigidbody/sequencer/Sequencer.cpp
+++ b/source/rigidbody/sequencer/Sequencer.cpp
@@ -25,6 +25,10 @@ LoopElement& Sequencer::end() {
     throw std::runtime_error("Sequencer::end: Too many end() calls detected.");
 }
 
+void Sequencer::run() {
+    throw std::logic_error("Sequencer::run: Use execute() to run the sequencer. Calling run() directly skips rigidbody and controller initialization.");
+}
+
 observer_ptr<rigidbody::Rigidbody> Sequencer::_get_rigidbody() const {
     assert(rigidbody != nullptr && "Sequencer::_get_rigidbody: Rigidbody not set.");
     return rigidbody;

--- a/source/rigidbody/sequencer/detail/AdditionalElements.cpp
+++ b/source/rigidbody/sequencer/detail/AdditionalElements.cpp
@@ -2,6 +2,7 @@
 // Author: Kristian Lytje
 
 #include <rigidbody/sequencer/detail/AdditionalElements.h>
+#include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/sequencer/elements/MessageElement.h>
 #include <utility/StringUtils.h>
@@ -43,4 +44,20 @@ void detail::OverlapStrengthElement::_parse(observer_ptr<LoopElement> owner, Par
     if (!scaling.found) {throw except::parse_error("overlap_strength", "Missing required argument \"scaling\".");}
     if (!distance.found) {throw except::parse_error("overlap_strength", "Missing required argument \"distance\".");}
     owner->_get_sequencer()->setup().set_overlap_function([a=scaling.value, d=distance.value] (double x) {return x < d ? a*std::pow((d-x)/d, 2) : 0;});
+}
+
+namespace {
+    enum class OverlapArgs {scaling, distance};
+    std::unordered_map<OverlapArgs, std::vector<std::string>> overlap_args_map = {
+        {OverlapArgs::scaling, {"scaling", "factor"}},
+        {OverlapArgs::distance, {"max", "max_distance", "distance"}}
+    };
+}
+
+std::vector<std::string> detail::SeedElement::_valid_arguments() { return {}; }
+std::vector<std::string> detail::LoopEndElement::_valid_arguments() { return {}; }
+std::vector<std::string> detail::LogElement::_valid_arguments() { return {}; }
+std::vector<std::string> detail::OverlapStrengthElement::_valid_arguments() {
+    static auto map = get_arg_names<OverlapArgs>(overlap_args_map);
+    return map;
 }

--- a/source/rigidbody/sequencer/detail/SequenceParser.cpp
+++ b/source/rigidbody/sequencer/detail/SequenceParser.cpp
@@ -148,16 +148,24 @@ ElementType get_type(std::string_view line) {
     throw parse_error("base", "Unknown element \"" + std::string(line) + "\".");
 }
 
-std::unique_ptr<Sequencer> SequenceParser::parse(const io::ExistingFile& config) {
+std::unique_ptr<Sequencer> SequenceParser::parse_text(const std::string& script) {
+    std::istringstream in(script);
+    return parse(in);
+}
+
+std::unique_ptr<Sequencer> SequenceParser::parse_file(const io::ExistingFile& config) {
     std::ifstream in(config.path());
     if (!in.is_open()) {throw ausaxs::except::io_error("SequenceParser::parse: Could not open file \"" + config.path() + "\".");}
+    return parse(in, config.directory());
+}
 
+std::unique_ptr<Sequencer> SequenceParser::parse(std::istream& in, const std::string& config_folder) {
     std::unique_ptr<Sequencer> sequencer = std::make_unique<Sequencer>(); // the main sequencer object
 
     // the top element of this stack is the current loop element which new elements will be added to
     // note that the sequencer itself is just a dummy loop element with an iteration count of 1
     loop_stack = {sequencer.get()};
-    sequencer->setup()._set_config_folder(config.directory());
+    sequencer->setup()._set_config_folder(config_folder);
 
     std::string line;
     int line_no = 0;
@@ -225,7 +233,7 @@ std::unique_ptr<Sequencer> SequenceParser::parse(const io::ExistingFile& config)
             {ElementType::AutomaticConstraint, AutoConstraintsElement::_parse},
             {ElementType::BodySelect,          BodySelectElement::_parse},
             {ElementType::Copy,                CopyBodyElement::_parse},
-            {ElementType::EveryNStep,           EveryNStepElement::_parse},
+            {ElementType::EveryNStep,          EveryNStepElement::_parse},
             {ElementType::LoadElement,         LoadElement::_parse},
             {ElementType::LoopBegin,           LoopElement::_parse},
             {ElementType::Message,             MessageElement::_parse},

--- a/source/rigidbody/sequencer/detail/SequenceParser.cpp
+++ b/source/rigidbody/sequencer/detail/SequenceParser.cpp
@@ -5,6 +5,7 @@
 #include <rigidbody/sequencer/detail/AdditionalElements.h>
 #include <rigidbody/sequencer/detail/ParsedArgs.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
+#include <rigidbody/sequencer/detail/ValidElements.h>
 #include <rigidbody/sequencer/elements/All.h>
 #include <utility/observer_ptr.h>
 #include <utility/Logging.h>
@@ -90,62 +91,6 @@ namespace {
         const auto& t = tokens.back();
         return t.size() == 1 && is_closing_brace(t[0]);
     }
-}
-
-enum class ElementType {
-    AutomaticConstraint,
-    BodySelect,
-    Constraint,
-    Copy,
-    EveryNStep,
-    LoadElement,
-    Log,
-    LoopBegin,
-    LoopEnd,
-    Message,
-    OnImprovement,
-    OptimizeStep,
-    OutputFolder,
-    OverlapStrength,
-    Parameter,
-    RelativeHydration,
-    Save,
-    Seed,
-    SymmetryElement,
-    Transform,
-};
-
-ElementType get_type(std::string_view line) {
-    static std::unordered_map<ElementType, std::vector<std::string>> type_map = {
-        {ElementType::AutomaticConstraint, {"autoconstrain", "autoconstraints"}},
-        {ElementType::BodySelect, {"select", "selector"}},
-        {ElementType::Constraint, {"constrain", "constraint"}},
-        {ElementType::Copy, {"copy", "copy_body"}},
-        {ElementType::EveryNStep, {"every"}},
-        {ElementType::LoadElement, {"load", "open"}},
-        {ElementType::Log, {"log"}},
-        {ElementType::LoopBegin, {"loop"}},
-        {ElementType::LoopEnd, {"end"}},
-        {ElementType::Message, {"print"}},
-        {ElementType::OnImprovement, {"on_improvement"}},
-        {ElementType::OptimizeStep, {"optimize_step", "optimize_once"}},
-        {ElementType::OutputFolder, {"output", "output_folder"}},
-        {ElementType::OverlapStrength, {"overlap_strength"}},
-        {ElementType::Parameter, {"parameter", "parameter_generator"}},
-        {ElementType::RelativeHydration, {"relative_hydration"}},
-        {ElementType::Save, {"save", "write"}},
-        {ElementType::Seed, {"seed"}},
-        {ElementType::SymmetryElement, {"symmetry"}},
-        {ElementType::Transform, {"transform", "transformer"}},
-    };
-    for (const auto& [type, prefixes] : type_map) {
-        for (const auto& prefix : prefixes) {
-            if (
-                line.starts_with(prefix) && (line.size() == prefix.size() || !std::isalpha(line[prefix.size()]))
-            ) {return type;}
-        }
-    }
-    throw parse_error("base", "Unknown element \"" + std::string(line) + "\".");
 }
 
 std::unique_ptr<Sequencer> SequenceParser::parse_text(const std::string& script) {

--- a/source/rigidbody/sequencer/detail/SequenceParser.cpp
+++ b/source/rigidbody/sequencer/detail/SequenceParser.cpp
@@ -17,6 +17,7 @@
 
 using namespace ausaxs;
 using namespace ausaxs::rigidbody::sequencer;
+using namespace ausaxs::rigidbody::sequencer::detail;
 
 using ausaxs::except::io_error;
 using ausaxs::rigidbody::sequencer::except::parse_error;

--- a/source/rigidbody/sequencer/detail/ValidElements.cpp
+++ b/source/rigidbody/sequencer/detail/ValidElements.cpp
@@ -9,7 +9,7 @@
 #include <unordered_map>
 #include <cassert>
 
-using namespace ausaxs::rigidbody::sequencer;
+using namespace ausaxs::rigidbody::sequencer::detail;
 
 const std::unordered_map<ElementType, std::vector<std::string>>& get_type_map() {
     static std::unordered_map<ElementType, std::vector<std::string>> type_map = {
@@ -37,7 +37,7 @@ const std::unordered_map<ElementType, std::vector<std::string>>& get_type_map() 
     return type_map;
 };
 
-std::vector<std::string> ausaxs::rigidbody::sequencer::valid_elements() {
+std::vector<std::string> ausaxs::rigidbody::sequencer::detail::valid_elements() {
     const auto& type_map = get_type_map();
     std::vector<std::string> elements; 
     elements.reserve(type_map.size() * 2); // reserve space for all prefixes (most elements have 2)
@@ -51,7 +51,7 @@ std::vector<std::string> ausaxs::rigidbody::sequencer::valid_elements() {
     return elements;
 }
 
-std::vector<std::string> ausaxs::rigidbody::sequencer::valid_arguments(ElementType type) {
+std::vector<std::string> ausaxs::rigidbody::sequencer::detail::valid_arguments(ElementType type) {
     switch (type) {
         case ElementType::AutomaticConstraint: return AutoConstraintsElement::_valid_arguments();
         case ElementType::BodySelect:          return BodySelectElement::_valid_arguments();
@@ -77,7 +77,7 @@ std::vector<std::string> ausaxs::rigidbody::sequencer::valid_arguments(ElementTy
     }
 }
 
-ElementType ausaxs::rigidbody::sequencer::get_type(std::string_view line) {
+ElementType ausaxs::rigidbody::sequencer::detail::get_type(std::string_view line) {
     const auto& type_map = get_type_map();
     for (const auto& [type, prefixes] : type_map) {
         for (const auto& prefix : prefixes) {

--- a/source/rigidbody/sequencer/detail/ValidElements.cpp
+++ b/source/rigidbody/sequencer/detail/ValidElements.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#include <rigidbody/sequencer/detail/ValidElements.h>
+#include <rigidbody/sequencer/detail/AdditionalElements.h>
+#include <rigidbody/sequencer/detail/parse_error.h>
+#include <rigidbody/sequencer/elements/All.h>
+
+#include <unordered_map>
+#include <cassert>
+
+using namespace ausaxs::rigidbody::sequencer;
+
+const std::unordered_map<ElementType, std::vector<std::string>>& get_type_map() {
+    static std::unordered_map<ElementType, std::vector<std::string>> type_map = {
+        {ElementType::AutomaticConstraint, {"autoconstrain", "autoconstraints"}},
+        {ElementType::BodySelect, {"select", "selector"}},
+        {ElementType::Constraint, {"constrain", "constraint"}},
+        {ElementType::Copy, {"copy", "copy_body"}},
+        {ElementType::EveryNStep, {"every"}},
+        {ElementType::LoadElement, {"load", "open"}},
+        {ElementType::Log, {"log"}},
+        {ElementType::LoopBegin, {"loop"}},
+        {ElementType::LoopEnd, {"end"}},
+        {ElementType::Message, {"print"}},
+        {ElementType::OnImprovement, {"on_improvement"}},
+        {ElementType::OptimizeStep, {"optimize_step", "optimize_once"}},
+        {ElementType::OutputFolder, {"output", "output_folder"}},
+        {ElementType::OverlapStrength, {"overlap_strength"}},
+        {ElementType::Parameter, {"parameter", "parameter_generator"}},
+        {ElementType::RelativeHydration, {"relative_hydration"}},
+        {ElementType::Save, {"save", "write"}},
+        {ElementType::Seed, {"seed"}},
+        {ElementType::SymmetryElement, {"symmetry"}},
+        {ElementType::Transform, {"transform", "transformer"}},
+    };
+    return type_map;
+};
+
+std::vector<std::string> ausaxs::rigidbody::sequencer::valid_elements() {
+    const auto& type_map = get_type_map();
+    std::vector<std::string> elements; 
+    elements.reserve(type_map.size() * 2); // reserve space for all prefixes (most elements have 2)
+    for (int i = 0; i < static_cast<int>(ElementType::COUNT); ++i) {
+        ElementType type = static_cast<ElementType>(i);
+        assert(type_map.contains(type));
+        for (const auto& prefix : type_map.at(type)) {
+            elements.emplace_back(prefix);
+        }
+    }
+    return elements;
+}
+
+std::vector<std::string> ausaxs::rigidbody::sequencer::valid_arguments(ElementType type) {
+    switch (type) {
+        case ElementType::AutomaticConstraint: return AutoConstraintsElement::_valid_arguments();
+        case ElementType::BodySelect:          return BodySelectElement::_valid_arguments();
+        case ElementType::Constraint:          return ConstraintElement::_valid_arguments();
+        case ElementType::Copy:                return CopyBodyElement::_valid_arguments();
+        case ElementType::EveryNStep:          return EveryNStepElement::_valid_arguments();
+        case ElementType::LoadElement:         return LoadElement::_valid_arguments();
+        case ElementType::Log:                 return detail::LogElement::_valid_arguments();
+        case ElementType::LoopBegin:           return LoopElement::_valid_arguments();
+        case ElementType::LoopEnd:             return detail::LoopEndElement::_valid_arguments();
+        case ElementType::Message:             return MessageElement::_valid_arguments();
+        case ElementType::OnImprovement:       return OnImprovementElement::_valid_arguments();
+        case ElementType::OptimizeStep:        return OptimizeStepElement::_valid_arguments();
+        case ElementType::OutputFolder:        return OutputFolderElement::_valid_arguments();
+        case ElementType::OverlapStrength:     return detail::OverlapStrengthElement::_valid_arguments();
+        case ElementType::Parameter:           return ParameterElement::_valid_arguments();
+        case ElementType::RelativeHydration:   return RelativeHydrationElement::_valid_arguments();
+        case ElementType::Save:                return SaveElement::_valid_arguments();
+        case ElementType::Seed:                return detail::SeedElement::_valid_arguments();
+        case ElementType::SymmetryElement:     return SymmetryElement::_valid_arguments();
+        case ElementType::Transform:           return TransformElement::_valid_arguments();
+        default: return {};
+    }
+}
+
+ElementType ausaxs::rigidbody::sequencer::get_type(std::string_view line) {
+    const auto& type_map = get_type_map();
+    for (const auto& [type, prefixes] : type_map) {
+        for (const auto& prefix : prefixes) {
+            if (line.starts_with(prefix) && (line.size() == prefix.size() || !std::isalpha(line[prefix.size()]))) {
+                return type;
+            }
+        }
+    }
+    throw except::parse_error("base", "Unknown element \"" + std::string(line) + "\".");
+}

--- a/source/rigidbody/sequencer/elements/BodySelectElement.cpp
+++ b/source/rigidbody/sequencer/elements/BodySelectElement.cpp
@@ -3,6 +3,7 @@
 
 #include <rigidbody/sequencer/elements/BodySelectElement.h>
 #include <rigidbody/sequencer/elements/LoopElement.h>
+#include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/selection/BodySelectFactory.h>
 #include <rigidbody/Rigidbody.h>
@@ -14,6 +15,19 @@ BodySelectElement::~BodySelectElement() = default;
 
 void BodySelectElement::run() {
     owner->_get_rigidbody()->body_selector = strategy;
+}
+
+namespace {
+    enum class Args {strategy, parameters};
+    std::unordered_map<Args, std::vector<std::string>> args_map = {
+        {Args::strategy,   {"point", "body"}},
+        {Args::parameters, {"parameters", "parameter_mask", "mask"}},
+    };
+}
+
+std::vector<std::string> BodySelectElement::_valid_arguments() {
+    static auto map = detail::get_arg_names<Args>(args_map);
+    return map;
 }
 
 std::unique_ptr<GenericElement> BodySelectElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {

--- a/source/rigidbody/sequencer/elements/ConvertSymmetryElement.cpp
+++ b/source/rigidbody/sequencer/elements/ConvertSymmetryElement.cpp
@@ -16,3 +16,7 @@ ConvertSymmetryElement::~ConvertSymmetryElement() = default;
 void ConvertSymmetryElement::run() {
     assert(false && "ConvertSymmetryElement::run: Not implemented.");
 }
+
+std::vector<std::string> ConvertSymmetryElement::_valid_arguments() {
+    return {};
+}

--- a/source/rigidbody/sequencer/elements/EveryNStepElement.cpp
+++ b/source/rigidbody/sequencer/elements/EveryNStepElement.cpp
@@ -19,6 +19,10 @@ void EveryNStepElement::run() {
     }
 }
 
+std::vector<std::string> EveryNStepElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> EveryNStepElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     if (!args.named.empty()) {throw except::parse_error("every_n_step", "Unexpected named argument.");}
     if (args.inlined.size() != 1) {throw except::parse_error("every_n_step", "Expected exactly one inline argument.");}

--- a/source/rigidbody/sequencer/elements/LoopElement.cpp
+++ b/source/rigidbody/sequencer/elements/LoopElement.cpp
@@ -141,6 +141,10 @@ void LoopElement::_add_total_iterations(unsigned int n) {
     total_loop_count += n;
 }
 
+std::vector<std::string> LoopElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> LoopElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     static std::unordered_map<std::string, observer_ptr<LoopElement>> loop_names;
     static observer_ptr<LoopElement> last_loop_element = nullptr;

--- a/source/rigidbody/sequencer/elements/MessageElement.cpp
+++ b/source/rigidbody/sequencer/elements/MessageElement.cpp
@@ -3,6 +3,7 @@
 
 #include <rigidbody/sequencer/elements/MessageElement.h>
 #include <rigidbody/sequencer/Sequencer.h>
+#include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/detail/MoleculeTransformParametersAbsolute.h>
 #include <rigidbody/constraints/ConstrainedFitter.h>
@@ -84,6 +85,19 @@ MessageElement::~MessageElement() = default;
 void MessageElement::run() {
     assert(message_func && "MessageElement::run: message_func is not set.");
     message_func();
+}
+
+namespace {
+    enum class Args {message, color};
+    std::unordered_map<Args, std::vector<std::string>> args_map = {
+        {Args::message, {"message", "msg"}},
+        {Args::color, {"color", "colour"}}
+    };
+}
+
+std::vector<std::string> MessageElement::_valid_arguments() {
+    static auto map = detail::get_arg_names<Args>(args_map);
+    return map;
 }
 
 std::unique_ptr<GenericElement> MessageElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {

--- a/source/rigidbody/sequencer/elements/OnImprovementElement.cpp
+++ b/source/rigidbody/sequencer/elements/OnImprovementElement.cpp
@@ -21,6 +21,10 @@ void OnImprovementElement::run() {
     }
 }
 
+std::vector<std::string> OnImprovementElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> OnImprovementElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     if (!args.named.empty()) {throw except::parse_error("on_improvement", "Unexpected named argument.");}
     if (!args.inlined.empty()) {throw except::parse_error("on_improvement", "Unexpected inline argument.");}

--- a/source/rigidbody/sequencer/elements/OptimizeStepElement.cpp
+++ b/source/rigidbody/sequencer/elements/OptimizeStepElement.cpp
@@ -28,6 +28,10 @@ void OptimizeStepElement::run() {
     _get_sequencer()->_get_controller()->finish_step();
 }
 
+std::vector<std::string> OptimizeStepElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> OptimizeStepElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     if (!args.named.empty()) {throw except::parse_error("optimize_step", "Unexpected named argument.");}
     if (!args.inlined.empty()) {throw except::parse_error("optimize_step", "Unexpected inline argument.");}

--- a/source/rigidbody/sequencer/elements/ParameterElement.cpp
+++ b/source/rigidbody/sequencer/elements/ParameterElement.cpp
@@ -3,6 +3,7 @@
 
 #include <rigidbody/sequencer/elements/ParameterElement.h>
 #include <rigidbody/sequencer/elements/LoopElement.h>
+#include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/parameters/decay/DecayFactory.h>
 #include <rigidbody/parameters/ParameterGenerationFactory.h>
@@ -46,6 +47,22 @@ namespace {
         static inline std::string BOTH = "both";
         static inline std::string SYMMETRY_ONLY = "symmetry_only";
     };
+}
+
+namespace {
+    enum class Args {iterations, translate, rotate, strategy, decay_strategy};
+    std::unordered_map<Args, std::vector<std::string>> args_map = {
+        {Args::iterations,      {"iterations"}},
+        {Args::translate,       {"translate"}},
+        {Args::rotate,          {"rotate"}},
+        {Args::strategy,        {"mode", "strategy"}},
+        {Args::decay_strategy,  {"decay"}}
+    };
+}
+
+std::vector<std::string> ParameterElement::_valid_arguments() {
+    static auto map = detail::get_arg_names<Args>(args_map);
+    return map;
 }
 
 std::unique_ptr<GenericElement> ParameterElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {

--- a/source/rigidbody/sequencer/elements/SaveElement.cpp
+++ b/source/rigidbody/sequencer/elements/SaveElement.cpp
@@ -57,6 +57,10 @@ void SaveElement::run() {
     }
 }
 
+std::vector<std::string> SaveElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> SaveElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     if (!args.named.empty()) {throw except::parse_error("save", "Unexpected named argument.");}
     if (args.inlined.size() != 1) {throw except::parse_error("save", "Expected only a single inline argument.");}

--- a/source/rigidbody/sequencer/elements/TransformElement.cpp
+++ b/source/rigidbody/sequencer/elements/TransformElement.cpp
@@ -17,6 +17,10 @@ void TransformElement::run() {
     owner->_get_rigidbody()->transformer = strategy;
 }
 
+std::vector<std::string> TransformElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> TransformElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     if (!args.named.empty()) {throw except::parse_error("transform", "Unexpected named arguments.");}
     if (args.inlined.size() != 1) {throw except::parse_error("transform", "Expected only a single inline argument.");}

--- a/source/rigidbody/sequencer/elements/setup/AutoConstraintsElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/AutoConstraintsElement.cpp
@@ -18,6 +18,10 @@ void AutoConstraintsElement::run() {
     owner->_get_rigidbody()->constraints->generate_constraints(rigidbody::factory::generate_constraints(owner->_get_rigidbody()->constraints.get(), strategy));
 }
 
+std::vector<std::string> AutoConstraintsElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> AutoConstraintsElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     static auto get_constraint_strategy = [] (std::string_view line) {
         if (line == "none") {return settings::rigidbody::ConstraintGenerationStrategyChoice::None;}

--- a/source/rigidbody/sequencer/elements/setup/ConstraintElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/ConstraintElement.cpp
@@ -3,6 +3,7 @@
 
 #include <rigidbody/sequencer/Sequencer.h>
 #include <rigidbody/sequencer/elements/setup/ConstraintElement.h>
+#include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/constraints/ConstraintManager.h>
 #include <rigidbody/constraints/IDistanceConstraint.h>
@@ -26,6 +27,23 @@ namespace {
         BodyCMRepeller,
         Unknown
     };
+}
+
+namespace {
+    enum class Args {body1, body2, iatom1, iatom2, type, distance};
+    std::unordered_map<Args, std::vector<std::string>> args_map = {
+        {Args::body1, {"first", "body1"}},
+        {Args::body2, {"second", "body2"}},
+        {Args::iatom1, {"iatom1", "atom1"}},
+        {Args::iatom2, {"iatom2", "atom2"}},
+        {Args::type, {"type", "kind"}},
+        {Args::distance, {"distance", "dist"}}
+    };
+}
+
+std::vector<std::string> ConstraintElement::_valid_arguments() {
+    static auto map = detail::get_arg_names<Args>(args_map);
+    return map;
 }
 
 void ConstraintElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {

--- a/source/rigidbody/sequencer/elements/setup/CopyBodyElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/CopyBodyElement.cpp
@@ -40,6 +40,10 @@ CopyBodyElement::~CopyBodyElement() = default;
 
 void CopyBodyElement::run() {}
 
+std::vector<std::string> CopyBodyElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> CopyBodyElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     if (!args.named.empty()) {throw except::parse_error("copy", "Unexpected named argument \"" + args.named.begin()->first + "\".");}
     if (args.inlined.size() != 2) {throw except::parse_error(

--- a/source/rigidbody/sequencer/elements/setup/LoadElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/LoadElement.cpp
@@ -2,6 +2,7 @@
 // Author: Kristian Lytje
 
 #include <rigidbody/sequencer/Sequencer.h>
+#include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/sequencer/elements/setup/LoadElement.h>
 #include <rigidbody/sequencer/elements/setup/BodySymmetrySelector.h>
@@ -171,6 +172,21 @@ std::vector<std::string> LoadElement::load_wildcarded(const std::string& path) {
 
 void LoadElement::run() {
     owner->_get_sequencer()->_set_rigidbody(rigidbody.get());
+}
+
+namespace {
+    enum class Args {paths, splits, names, saxs};
+    std::unordered_map<Args, std::vector<std::string>> args_map = {
+        {Args::paths, {"pdb"}},
+        {Args::saxs, {"saxs"}},
+        {Args::splits, {"split"}},
+        {Args::names, {"names", "name"}}
+    };
+}
+
+std::vector<std::string> LoadElement::_valid_arguments() {
+    static auto map = detail::get_arg_names<Args>(args_map);
+    return map;
 }
 
 std::unique_ptr<GenericElement> LoadElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {

--- a/source/rigidbody/sequencer/elements/setup/LoadExistingElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/LoadExistingElement.cpp
@@ -14,3 +14,7 @@ LoadExistingElement::LoadExistingElement(observer_ptr<Sequencer> owner, observer
 void LoadExistingElement::run() {
     owner->_get_sequencer()->_set_rigidbody(rigidbody);
 }
+
+std::vector<std::string> LoadExistingElement::_valid_arguments() {
+    return {};
+}

--- a/source/rigidbody/sequencer/elements/setup/OutputFolderElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/OutputFolderElement.cpp
@@ -3,6 +3,7 @@
 
 #include <rigidbody/sequencer/elements/setup/OutputFolderElement.h>
 #include <rigidbody/sequencer/elements/setup/SetupElement.h>
+#include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/sequencer/Sequencer.h>
 #include <rigidbody/Rigidbody.h>
@@ -28,6 +29,19 @@ OutputFolderElement::OutputFolderElement(observer_ptr<Sequencer> owner, const io
 }
 
 void OutputFolderElement::run() {}
+
+namespace {
+    enum class Args {path, mode};
+    std::unordered_map<Args, std::vector<std::string>> args_map = {
+        {Args::path, {"path", "folder", "anonymous"}},
+        {Args::mode, {"mode", "relative"}}
+    };
+}
+
+std::vector<std::string> OutputFolderElement::_valid_arguments() {
+    static auto map = detail::get_arg_names<Args>(args_map);
+    return map;
+}
 
 std::unique_ptr<GenericElement> OutputFolderElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     enum class Args {path, mode};

--- a/source/rigidbody/sequencer/elements/setup/RelativeHydrationElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/RelativeHydrationElement.cpp
@@ -40,6 +40,10 @@ void RelativeHydrationElement::run() {
     owner->_get_molecule()->generate_new_hydration();
 }
 
+std::vector<std::string> RelativeHydrationElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> RelativeHydrationElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     enum class Options {Maximum, High, Normal, Low, Minimum};
     static std::unordered_map<std::string, Options> options = {

--- a/source/rigidbody/sequencer/elements/setup/SymmetryElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/SymmetryElement.cpp
@@ -64,6 +64,10 @@ SymmetryElement::~SymmetryElement() = default;
 
 void SymmetryElement::run() {}
 
+std::vector<std::string> SymmetryElement::_valid_arguments() {
+    return {};
+}
+
 std::unique_ptr<GenericElement> SymmetryElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     auto rigidbody = owner->_get_rigidbody();
 

--- a/tests/feature/rigidbody/sequence_parser.cpp
+++ b/tests/feature/rigidbody/sequence_parser.cpp
@@ -32,7 +32,7 @@ TEST_CASE("SequenceParser: parse minimal config", "[files]") {
     }
 
     SequenceParser parser;
-    auto sequencer = parser.parse(io::ExistingFile(config_path));
+    auto sequencer = parser.parse_file(config_path);
     REQUIRE(sequencer != nullptr);
 
     auto result = sequencer->execute();
@@ -47,7 +47,7 @@ TEST_CASE("SequenceParser: parse normal config with output folder", "[files]") {
     settings::grid::min_bins = 250;
 
     SequenceParser parser;
-    auto sequencer = parser.parse(io::ExistingFile("tests/files/rigidbody/normal.conf"));
+    auto sequencer = parser.parse_file("tests/files/rigidbody/normal.conf");
     REQUIRE(sequencer != nullptr);
 
     auto result = sequencer->execute();
@@ -62,7 +62,7 @@ TEST_CASE("SequenceParser: parse symmetry config", "[files]") {
     settings::grid::min_bins = 250;
 
     SequenceParser parser;
-    auto sequencer = parser.parse(io::ExistingFile("tests/files/rigidbody/symmetry.conf"));
+    auto sequencer = parser.parse_file("tests/files/rigidbody/symmetry.conf");
     REQUIRE(sequencer != nullptr);
 
     auto result = sequencer->execute();

--- a/tests/unit/rigidbody/elements/sequence_parser_symmetry.cpp
+++ b/tests/unit/rigidbody/elements/sequence_parser_symmetry.cpp
@@ -35,7 +35,7 @@ struct SequenceParserSymmetryFixture {
         f << content;
         f.close();
         SequenceParser parser;
-        return parser.parse(io::ExistingFile(path));
+        return parser.parse_file(path);
     }
 };
 


### PR DESCRIPTION
This PR adds functionality for validating rigidbody config script files without actually running them. The validation is, at this stage, still basic, and only ensures the provided args will be accepted. 