### PR TITLE
Body selectors now use live body count

### DIFF
--- a/include/rigidbody/rigidbody/selection/BodySelectFactory.h
+++ b/include/rigidbody/rigidbody/selection/BodySelectFactory.h
@@ -21,5 +21,18 @@ namespace ausaxs::rigidbody {
             settings::rigidbody::BodySelectStrategyChoice body_choice,
             settings::rigidbody::ParameterMaskStrategyChoice mask_choice
         );
+
+        /**
+         * @brief Create a ManualSelect strategy that always selects the given body.
+         *
+         * @param ibody The index of the body to select on every call.
+         */
+        std::unique_ptr<selection::BodySelectStrategy> create_manual_selection_strategy(
+            observer_ptr<const Rigidbody> molecule, unsigned int ibody
+        );
+
+        std::unique_ptr<selection::BodySelectStrategy> create_manual_selection_strategy(
+            observer_ptr<const Rigidbody> molecule, unsigned int ibody, settings::rigidbody::ParameterMaskStrategyChoice mask_choice
+        );
     }
 }

--- a/include/rigidbody/rigidbody/selection/BodySelectStrategy.h
+++ b/include/rigidbody/rigidbody/selection/BodySelectStrategy.h
@@ -49,9 +49,13 @@ namespace ausaxs::rigidbody {
                  */
                 void set_mask_strategy(std::unique_ptr<ParameterMaskStrategy> strategy);
 
-            protected: 
+            protected:
                 observer_ptr<const Rigidbody> rigidbody;
-                unsigned int N;
+
+                /**
+                 * @brief The current number of bodies in the molecule.
+                 */
+                unsigned int size_body() const;
 
             private:
                 std::unique_ptr<ParameterMaskStrategy> mask_strategy;

--- a/include/rigidbody/rigidbody/selection/ManualSelect.h
+++ b/include/rigidbody/rigidbody/selection/ManualSelect.h
@@ -8,18 +8,17 @@
 namespace ausaxs::rigidbody {
     namespace selection {
         /**
-         * @brief The next body is manually selected, with the next constraint being a random one from the constraints connecting to that body.
+         * @brief A fixed body is selected on every call, with the next constraint being a random one from the constraints connecting to that body.
          */
         class ManualSelect : public BodySelectStrategy {
-            public: 
-                ManualSelect(observer_ptr<const Rigidbody> rigidbody);
+            public:
+                ManualSelect(observer_ptr<const Rigidbody> rigidbody, unsigned int ibody);
                 ~ManualSelect() override;
 
                 std::pair<unsigned int, int> next() override; ///< @copydoc BodySelectStrategy::next()
 
             private:
-                unsigned int ibody = 0; 		// The index of the body to be transformed. 
-                unsigned int iconstraint = 0; 	// The index of the constraint to be transformed.
+                unsigned int ibody; // The index of the body to be transformed.
         };
     }
 }

--- a/include/rigidbody/rigidbody/selection/RandomBodySelect.h
+++ b/include/rigidbody/rigidbody/selection/RandomBodySelect.h
@@ -5,8 +5,6 @@
 
 #include <rigidbody/selection/BodySelectStrategy.h>
 
-#include <random>
-
 namespace ausaxs::rigidbody {
     namespace selection {
         /**
@@ -18,9 +16,6 @@ namespace ausaxs::rigidbody {
                 ~RandomBodySelect() override;
 
                 std::pair<unsigned int, int> next() override; ///< @copydoc BodySelectStrategy::next()
-
-            private:
-                std::uniform_int_distribution<int> distribution; // The random number distribution. 
         };
     }
 }

--- a/include/rigidbody/rigidbody/selection/RandomConstraintSelect.h
+++ b/include/rigidbody/rigidbody/selection/RandomConstraintSelect.h
@@ -5,8 +5,6 @@
 
 #include <rigidbody/selection/BodySelectStrategy.h>
 
-#include <random>
-
 namespace ausaxs::rigidbody {
     namespace selection {
         /**
@@ -19,9 +17,6 @@ namespace ausaxs::rigidbody {
                 ~RandomConstraintSelect() override;
 
                 std::pair<unsigned int, int> next() override; ///< @copydoc BodySelectStrategy::next()
-
-            private:
-                std::uniform_int_distribution<int> distribution; // The random number distribution. 
         };
     }
 }

--- a/source/rigidbody/selection/BodySelectFactory.cpp
+++ b/source/rigidbody/selection/BodySelectFactory.cpp
@@ -2,6 +2,7 @@
 // Author: Kristian Lytje
 
 #include <rigidbody/selection/BodySelectFactory.h>
+#include <rigidbody/selection/ManualSelect.h>
 #include <rigidbody/selection/RandomBodySelect.h>
 #include <rigidbody/selection/RandomConstraintSelect.h>
 #include <rigidbody/selection/SequentialBodySelect.h>
@@ -59,9 +60,23 @@ std::unique_ptr<BodySelectStrategy> rigidbody::factory::create_selection_strateg
             strategy = std::make_unique<SequentialBodySelect>(body); break;
         case settings::rigidbody::BodySelectStrategyChoice::SequentialConstraintSelect:
             strategy = std::make_unique<SequentialConstraintSelect>(body); break;
+        case settings::rigidbody::BodySelectStrategyChoice::ManualSelect:
+            throw except::unknown_argument("rigidbody::factory::create_selection_strategy: ManualSelect requires a target body; use create_manual_selection_strategy instead.");
         default:
             throw except::unknown_argument("rigidbody::factory::create_selection_strategy: Unknown strategy. Did you forget to add it to the switch statement?");
     }
+    strategy->set_mask_strategy(create_mask_strategy(mask_choice));
+    return strategy;
+}
+
+std::unique_ptr<BodySelectStrategy> rigidbody::factory::create_manual_selection_strategy(observer_ptr<const Rigidbody> body, unsigned int ibody) {
+    return create_manual_selection_strategy(body, ibody, settings::rigidbody::parameter_mask_strategy);
+}
+
+std::unique_ptr<BodySelectStrategy> rigidbody::factory::create_manual_selection_strategy(
+    observer_ptr<const Rigidbody> body, unsigned int ibody, settings::rigidbody::ParameterMaskStrategyChoice mask_choice)
+{
+    auto strategy = std::make_unique<ManualSelect>(body, ibody);
     strategy->set_mask_strategy(create_mask_strategy(mask_choice));
     return strategy;
 }

--- a/source/rigidbody/selection/BodySelectStrategy.cpp
+++ b/source/rigidbody/selection/BodySelectStrategy.cpp
@@ -9,9 +9,13 @@
 using namespace ausaxs::rigidbody::selection;
 
 BodySelectStrategy::BodySelectStrategy(observer_ptr<const Rigidbody> rigidbody)
-    : rigidbody(rigidbody), N(rigidbody->molecule.size_body()),
+    : rigidbody(rigidbody),
       mask_strategy(std::make_unique<AllMaskStrategy>())
 {}
+
+unsigned int BodySelectStrategy::size_body() const {
+    return rigidbody->molecule.size_body();
+}
 
 BodySelectStrategy::SelectionResult BodySelectStrategy::next_mask() {
     auto [ibody, iconstraint] = next();

--- a/source/rigidbody/selection/ManualSelect.cpp
+++ b/source/rigidbody/selection/ManualSelect.cpp
@@ -2,14 +2,31 @@
 // Author: Kristian Lytje
 
 #include <rigidbody/selection/ManualSelect.h>
-#include <utility/Exceptions.h>
+#include <rigidbody/constraints/ConstraintManager.h>
+#include <rigidbody/Rigidbody.h>
+#include <utility/Random.h>
+
+#include <random>
 
 using namespace ausaxs::rigidbody::selection;
 
-ManualSelect::ManualSelect(observer_ptr<const Rigidbody> rigidbody) : BodySelectStrategy(rigidbody) {}
+ManualSelect::ManualSelect(observer_ptr<const Rigidbody> rigidbody, unsigned int ibody) : BodySelectStrategy(rigidbody), ibody(ibody) {}
 
 ManualSelect::~ManualSelect() = default;
 
 std::pair<unsigned int, int> ManualSelect::next() {
-    throw except::not_implemented("ManualSelect::next: Not implemented.");
+    unsigned int N = rigidbody->constraints->get_body_constraints(ibody).size();
+    switch (N) {
+        case 0: {
+            return std::make_pair(ibody, -1);
+        }
+        case 1: {
+            return std::make_pair(ibody, 0);
+        }
+        default: {
+            std::uniform_int_distribution<int> distribution(0, N-1);
+            unsigned int iconstraint = distribution(random::generator());
+            return std::make_pair(ibody, iconstraint);
+        }
+    }
 }

--- a/source/rigidbody/selection/RandomBodySelect.cpp
+++ b/source/rigidbody/selection/RandomBodySelect.cpp
@@ -7,15 +7,17 @@
 #include <utility/Exceptions.h>
 #include <utility/Random.h>
 
+#include <random>
+
 using namespace ausaxs::rigidbody::selection;
 
-RandomBodySelect::RandomBodySelect(observer_ptr<const Rigidbody> rigidbody) : BodySelectStrategy(rigidbody) {
-    distribution = std::uniform_int_distribution<int>(0, N-1);
-}
+RandomBodySelect::RandomBodySelect(observer_ptr<const Rigidbody> rigidbody) : BodySelectStrategy(rigidbody) {}
 
 RandomBodySelect::~RandomBodySelect() = default;
 
 std::pair<unsigned int, int> RandomBodySelect::next() {
+    // rebuild the distribution each call against the live body count
+    std::uniform_int_distribution<int> distribution(0, size_body()-1);
     unsigned int ibody = distribution(random::generator());
 
     unsigned int N = rigidbody->constraints->get_body_constraints(ibody).size();

--- a/source/rigidbody/selection/RandomConstraintSelect.cpp
+++ b/source/rigidbody/selection/RandomConstraintSelect.cpp
@@ -8,18 +8,18 @@
 #include <utility/Exceptions.h>
 #include <utility/Random.h>
 
+#include <random>
 #include <utility>
 
 using namespace ausaxs::rigidbody::selection;
 
-RandomConstraintSelect::RandomConstraintSelect(observer_ptr<const Rigidbody> rigidbody) : BodySelectStrategy(rigidbody) {
-    unsigned int M = rigidbody->constraints->discoverable_constraints.size();
-    distribution = std::uniform_int_distribution<int>(0, M-1);
-}
+RandomConstraintSelect::RandomConstraintSelect(observer_ptr<const Rigidbody> rigidbody) : BodySelectStrategy(rigidbody) {}
 
 RandomConstraintSelect::~RandomConstraintSelect() = default;
 
 std::pair<unsigned int, int> RandomConstraintSelect::next() {
+    // rebuild the distribution each call against the live constraint count
+    std::uniform_int_distribution<int> distribution(0, rigidbody->constraints->discoverable_constraints.size()-1);
     unsigned int iconstraint = distribution(random::generator());
     const auto& constraint = rigidbody->constraints->discoverable_constraints[iconstraint];
     unsigned int ibody = constraint->ibody1;

--- a/source/rigidbody/selection/RandomConstraintSelect.cpp
+++ b/source/rigidbody/selection/RandomConstraintSelect.cpp
@@ -18,6 +18,11 @@ RandomConstraintSelect::RandomConstraintSelect(observer_ptr<const Rigidbody> rig
 RandomConstraintSelect::~RandomConstraintSelect() = default;
 
 std::pair<unsigned int, int> RandomConstraintSelect::next() {
+    // constraints connect two bodies, so deleting bodies down to a point where none remain connected empties this list
+    if (rigidbody->constraints->discoverable_constraints.empty()) {
+        throw except::invalid_argument("RandomConstraintSelect::next: No constraints to select from.");
+    }
+
     // rebuild the distribution each call against the live constraint count
     std::uniform_int_distribution<int> distribution(0, rigidbody->constraints->discoverable_constraints.size()-1);
     unsigned int iconstraint = distribution(random::generator());

--- a/source/rigidbody/selection/SequentialBodySelect.cpp
+++ b/source/rigidbody/selection/SequentialBodySelect.cpp
@@ -17,7 +17,7 @@ SequentialBodySelect::~SequentialBodySelect() = default;
 std::pair<unsigned int, int> SequentialBodySelect::next() {
     unsigned int this_body = ibody;
     unsigned int M = rigidbody->constraints->get_body_constraints(this_body).size();
-    ibody = (ibody + 1) % N;
+    ibody = (ibody + 1) % size_body();
 
     switch (M) {
         case 0: {

--- a/source/rigidbody/selection/SequentialConstraintSelect.cpp
+++ b/source/rigidbody/selection/SequentialConstraintSelect.cpp
@@ -15,7 +15,7 @@ std::pair<unsigned int, int> SequentialConstraintSelect::next() {
     unsigned int M = rigidbody->constraints->get_body_constraints(ibody).size();
 
     if (iconstraint == M) {
-        ibody = (ibody + 1) % N;
+        ibody = (ibody + 1) % size_body();
         iconstraint = 0;
     }
 

--- a/source/rigidbody/sequencer/elements/BodySelectElement.cpp
+++ b/source/rigidbody/sequencer/elements/BodySelectElement.cpp
@@ -3,10 +3,13 @@
 
 #include <rigidbody/sequencer/elements/BodySelectElement.h>
 #include <rigidbody/sequencer/elements/LoopElement.h>
+#include <rigidbody/sequencer/Sequencer.h>
 #include <rigidbody/sequencer/detail/ArgumentHelper.h>
 #include <rigidbody/sequencer/detail/parse_error.h>
 #include <rigidbody/selection/BodySelectFactory.h>
 #include <rigidbody/Rigidbody.h>
+
+#include <optional>
 
 using namespace ausaxs::rigidbody::sequencer;
 
@@ -30,25 +33,54 @@ std::vector<std::string> BodySelectElement::_valid_arguments() {
     return map;
 }
 
+namespace {
+    std::optional<ausaxs::settings::rigidbody::BodySelectStrategyChoice> try_get_body_select_strategy(std::string_view line) {
+        using Choice = ausaxs::settings::rigidbody::BodySelectStrategyChoice;
+        if (line == "random_body") {return Choice::RandomBodySelect;}
+        if (line == "random_constraint") {return Choice::RandomConstraintSelect;}
+        if (line == "sequential_body") {return Choice::SequentialBodySelect;}
+        if (line == "sequential_constraint") {return Choice::SequentialConstraintSelect;}
+        return std::nullopt;
+    }
+}
+
 std::unique_ptr<GenericElement> BodySelectElement::_parse(observer_ptr<LoopElement> owner, ParsedArgs&& args) {
     enum class Args {strategy, parameters};
     static std::unordered_map<Args, std::vector<std::string>> valid_args = {
         {Args::strategy,   {"point", "body"}},
         {Args::parameters, {"parameters", "parameter_mask", "mask"}},
     };
+
+    // inline form: `select <strategy>` or `select <bodyname or alias>`
+    if (!args.inlined.empty()) {
+        if (!args.named.empty()) {throw except::parse_error("select", "Cannot mix inline and named arguments.");}
+        if (args.inlined.size() != 1) {
+            throw except::parse_error(
+                "select", "Invalid number of inline arguments. Expected exactly one strategy or body name/alias, but got " + std::to_string(args.inlined.size()) + "."
+            );
+        }
+
+        const std::string& token = args.inlined[0];
+        if (auto choice = try_get_body_select_strategy(token)) {
+            return std::make_unique<BodySelectElement>(owner, rigidbody::factory::create_selection_strategy(owner->_get_rigidbody(), *choice));
+        }
+
+        const auto& body_names = owner->_get_sequencer()->setup()._body_name_registry();
+        if (!body_names.contains(token)) {
+            throw except::parse_error("select", "Unknown body select strategy or body name/alias \"" + token + "\".");
+        }
+        return std::make_unique<BodySelectElement>(owner, rigidbody::factory::create_manual_selection_strategy(owner->_get_rigidbody(), body_names.resolve_body(token)));
+    }
+
     auto strategy = args.get<std::string>(valid_args[Args::strategy]);
     auto mask_arg = args.get<std::string>(valid_args[Args::parameters]);
 
-    if (!args.inlined.empty()) {throw except::parse_error("select", "Unexpected inline argument.");}
     if (args.named.size() < 1 || 2 < args.named.size()) {
         throw except::parse_error("select", "Invalid number of arguments. Expected 1 or 2, but got " + std::to_string(args.named.size()) + ".");
     }
 
     static auto get_body_select_strategy = [] (std::string_view line) {
-        if (line == "random_body") {return settings::rigidbody::BodySelectStrategyChoice::RandomBodySelect;}
-        if (line == "random_constraint") {return settings::rigidbody::BodySelectStrategyChoice::RandomConstraintSelect;}
-        if (line == "sequential_body") {return settings::rigidbody::BodySelectStrategyChoice::SequentialBodySelect;}
-        if (line == "sequential_constraint") {return settings::rigidbody::BodySelectStrategyChoice::SequentialConstraintSelect;}
+        if (auto choice = try_get_body_select_strategy(line)) {return *choice;}
         throw except::parse_error("select", "Unknown choice \"" + std::string(line) + "\"");
     };
 

--- a/tests/unit/rigidbody/elements/sequence_parser_select.cpp
+++ b/tests/unit/rigidbody/elements/sequence_parser_select.cpp
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Author: Kristian Lytje
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <rigidbody/sequencer/detail/SequenceParser.h>
+#include <rigidbody/sequencer/Sequencer.h>
+#include <rigidbody/Rigidbody.h>
+#include <rigidbody/selection/ManualSelect.h>
+#include <data/Molecule.h>
+#include <data/Body.h>
+#include <settings/All.h>
+#include <io/ExistingFile.h>
+
+#include <fstream>
+
+using namespace ausaxs;
+using namespace ausaxs::rigidbody;
+using namespace ausaxs::rigidbody::sequencer;
+
+struct SequenceParserSelectFixture {
+    SequenceParserSelectFixture() {
+        settings::general::verbose = false;
+        settings::molecule::implicit_hydrogens = false;
+        settings::grid::min_bins = 250;
+        settings::rigidbody::constraint_generation_strategy = settings::rigidbody::ConstraintGenerationStrategyChoice::None;
+    }
+
+    std::unique_ptr<Sequencer> parse(const std::string& content) {
+        static int counter = 0;
+        std::string path = "/tmp/ausaxs_seq_select_test_" + std::to_string(counter++) + ".conf";
+        std::ofstream f(path);
+        f << content;
+        f.close();
+        SequenceParser parser;
+        return parser.parse_file(path);
+    }
+};
+
+TEST_CASE_METHOD(SequenceParserSelectFixture, "SequenceParser::BodySelectElement inline") {
+    SECTION("selecting a body name switches to ManualSelect targeting that body") {
+        auto seq = parse(
+            "load {\n"
+            "    pdb tests/files/SASDJG5_single.pdb tests/files/SASDJG5_single.pdb\n"
+            "    saxs tests/files/SASDJG5.dat\n"
+            "}\n"
+            "select b2\n"
+        );
+        REQUIRE(seq != nullptr);
+        seq->execute();
+        auto rb = seq->_get_rigidbody();
+        REQUIRE(rb != nullptr);
+        REQUIRE(rb->body_selector != nullptr);
+        CHECK(dynamic_cast<selection::ManualSelect*>(rb->body_selector.get()) != nullptr);
+    }
+
+    SECTION("selecting a known strategy name inline works without braces") {
+        auto seq = parse(
+            "load {\n"
+            "    pdb tests/files/SASDJG5_single.pdb tests/files/SASDJG5_single.pdb\n"
+            "    saxs tests/files/SASDJG5.dat\n"
+            "}\n"
+            "select sequential_body\n"
+        );
+        REQUIRE(seq != nullptr);
+        seq->execute();
+        auto rb = seq->_get_rigidbody();
+        REQUIRE(rb != nullptr);
+        REQUIRE(rb->body_selector != nullptr);
+        CHECK(dynamic_cast<selection::ManualSelect*>(rb->body_selector.get()) == nullptr);
+    }
+
+    SECTION("selecting an unknown body name or strategy is rejected") {
+        CHECK_THROWS(parse(
+            "load {\n"
+            "    pdb tests/files/SASDJG5_single.pdb\n"
+            "    saxs tests/files/SASDJG5.dat\n"
+            "}\n"
+            "select doesnotexist\n"
+        ));
+    }
+
+    SECTION("more than one inline argument is rejected") {
+        CHECK_THROWS(parse(
+            "load {\n"
+            "    pdb tests/files/SASDJG5_single.pdb tests/files/SASDJG5_single.pdb\n"
+            "    saxs tests/files/SASDJG5.dat\n"
+            "}\n"
+            "select b1 b2\n"
+        ));
+    }
+
+    SECTION("named argument block form still works") {
+        auto seq = parse(
+            "load {\n"
+            "    pdb tests/files/SASDJG5_single.pdb tests/files/SASDJG5_single.pdb\n"
+            "    saxs tests/files/SASDJG5.dat\n"
+            "}\n"
+            "select {\n"
+            "    point random_body\n"
+            "}\n"
+        );
+        REQUIRE(seq != nullptr);
+        seq->execute();
+        auto rb = seq->_get_rigidbody();
+        REQUIRE(rb != nullptr);
+        REQUIRE(rb->body_selector != nullptr);
+    }
+}

--- a/tests/unit/rigidbody/selection_strategies.cpp
+++ b/tests/unit/rigidbody/selection_strategies.cpp
@@ -63,6 +63,29 @@ TEST_CASE_METHOD(SelectionStrategiesFixture, "SelectionStrategies::RandomBodySel
     }
 }
 
+TEST_CASE_METHOD(SelectionStrategiesFixture, "SelectionStrategies::ManualSelect") {
+    SECTION("next always returns the configured body") {
+        ManualSelect selector(rb.get(), 2);
+
+        for (int i = 0; i < 10; ++i) {
+            auto [ibody, iconstraint] = selector.next();
+            CHECK(ibody == 2);
+        }
+    }
+
+    SECTION("next returns -1 for a body with no constraints") {
+        Rigidbody isolated(Molecule{std::vector<Body>{
+            Body(std::vector{AtomFF({0, 0, 0}, form_factor::form_factor_t::C)}),
+            Body(std::vector{AtomFF({5, 0, 0}, form_factor::form_factor_t::C)})
+        }});
+        ManualSelect selector(&isolated, 0);
+
+        auto [ibody, iconstraint] = selector.next();
+        CHECK(ibody == 0);
+        CHECK(iconstraint == -1);
+    }
+}
+
 TEST_CASE_METHOD(SelectionStrategiesFixture, "SelectionStrategies::SequentialBodySelect") {
     SequentialBodySelect selector(rb.get());
 

--- a/tests/unit/rigidbody/selection_strategies.cpp
+++ b/tests/unit/rigidbody/selection_strategies.cpp
@@ -6,6 +6,7 @@
 #include <rigidbody/selection/SequentialConstraintSelect.h>
 #include <rigidbody/selection/ManualSelect.h>
 #include <rigidbody/Rigidbody.h>
+#include <rigidbody/BodySplitter.h>
 #include <rigidbody/constraints/ConstraintManager.h>
 #include <rigidbody/constraints/DistanceConstraintCM.h>
 #include <data/Molecule.h>
@@ -64,13 +65,77 @@ TEST_CASE_METHOD(SelectionStrategiesFixture, "SelectionStrategies::RandomBodySel
 
 TEST_CASE_METHOD(SelectionStrategiesFixture, "SelectionStrategies::SequentialBodySelect") {
     SequentialBodySelect selector(rb.get());
-    
+
     SECTION("next cycles through bodies in order") {
         unsigned int num_bodies = rb->molecule.get_bodies().size();
-        
+
         for (unsigned int i = 0; i < num_bodies * 2; ++i) {
             auto [ibody, iconstraint] = selector.next();
             CHECK(ibody == i % num_bodies);
+        }
+    }
+}
+
+// Regression test: strategies used to cache the body count at construction. If bodies were later removed (e.g. by the "delete", "merge", or "convert_to_symmetry" 
+// sequencer elements), next() could still return indices from the old, larger range, and callers like LimitedParameterGenerator::next() would index out of bounds.
+TEST_CASE_METHOD(SelectionStrategiesFixture, "SelectionStrategies::stale body count after removal") {
+    SECTION("RandomBodySelect") {
+        RandomBodySelect selector(rb.get());
+        rb->molecule.get_bodies().resize(1);
+
+        for (int i = 0; i < 50; ++i) {
+            auto [ibody, iconstraint] = selector.next();
+            CHECK(ibody < rb->molecule.get_bodies().size());
+        }
+    }
+
+    SECTION("SequentialBodySelect") {
+        SequentialBodySelect selector(rb.get());
+        rb->molecule.get_bodies().resize(1);
+
+        for (int i = 0; i < 50; ++i) {
+            auto [ibody, iconstraint] = selector.next();
+            CHECK(ibody < rb->molecule.get_bodies().size());
+        }
+    }
+
+    SECTION("RandomConstraintSelect") {
+        // DistanceConstraintBond (the discoverable constraint type RandomConstraintSelect samples from) requires C-alpha backbone metadata, so load a real 
+        // structure via BodySplitter with the Backbone generation strategy instead of hand-building one (see distance_constraint_bond.cpp)
+        settings::rigidbody::constraint_generation_strategy = settings::rigidbody::ConstraintGenerationStrategyChoice::Backbone;
+        Rigidbody local_rb = BodySplitter::split("tests/files/LAR1-4.pdb", {9, 99, 202, 292});
+        REQUIRE(local_rb.constraints->discoverable_constraints.size() == 4); // one bond between each of the 5 sequential bodies
+
+        RandomConstraintSelect selector(&local_rb);
+
+        // shrink the constraint list after the selector is constructed; next() used to sample from a distribution fixed at construction time, so this could 
+        // pick a since-removed constraint
+        local_rb.constraints->discoverable_constraints.resize(1);
+
+        for (int i = 0; i < 50; ++i) {
+            auto [ibody, iconstraint] = selector.next();
+            CHECK(ibody < local_rb.molecule.get_bodies().size());
+        }
+
+        settings::rigidbody::constraint_generation_strategy = settings::rigidbody::ConstraintGenerationStrategyChoice::None;
+    }
+
+    SECTION("RandomConstraintSelect throws instead of crashing once no constraints remain") {
+        RandomConstraintSelect selector(rb.get());
+
+        // the fixture never registers any discoverable constraints (only non-discoverable DistanceConstraintCM ones), so next() must throw rather than build 
+        // a distribution over an empty range (UB from uniform_int_distribution(0, -1))
+        REQUIRE(rb->constraints->discoverable_constraints.empty());
+        CHECK_THROWS(selector.next());
+    }
+
+    SECTION("SequentialConstraintSelect") {
+        SequentialConstraintSelect selector(rb.get());
+        rb->molecule.get_bodies().resize(1);
+
+        for (int i = 0; i < 50; ++i) {
+            auto [ibody, iconstraint] = selector.next();
+            CHECK(ibody < rb->molecule.get_bodies().size());
         }
     }
 }


### PR DESCRIPTION
This PR fixes a common crash when using the new `delete` or `merge` elements which modifies the number of bodies. Since all selectors were getting this number at construction-time, they became stale, leading to segfaults.