### PR TITLE
Fix histogram resets

### DIFF
--- a/include/core/settings/Flags.h
+++ b/include/core/settings/Flags.h
@@ -12,11 +12,6 @@ namespace ausaxs::settings {
         static bool init_histogram_manager; // Whether to initialize the histogram manager when a Molecule is created.
         static bool custom_bin_width;       // Whether a custom bin width is being used for the distance histogram.
         static double inv_bin_width;        // The inverse of the bin width for the distance histogram.
-
-        // Whether the caller intends to perform many incremental updates, and should therefore be given a partial
-        // histogram manager if one is available for the chosen excluded volume method. Set by the rigid-body
-        // machinery, which recalculates after every transformation. Unlike symmetry-awareness - which is derived
-        // from the molecule itself - this cannot be deduced from the data, only from how it is going to be used.
-        static bool prefer_partial_manager;
+        static bool prefer_partial_manager; // Whether to prefer a partial histogram manager if one is available for the chosen excluded volume method.
     };
 }

--- a/include/core/settings/Flags.h
+++ b/include/core/settings/Flags.h
@@ -12,5 +12,11 @@ namespace ausaxs::settings {
         static bool init_histogram_manager; // Whether to initialize the histogram manager when a Molecule is created.
         static bool custom_bin_width;       // Whether a custom bin width is being used for the distance histogram.
         static double inv_bin_width;        // The inverse of the bin width for the distance histogram.
+
+        // Whether the caller intends to perform many incremental updates, and should therefore be given a partial
+        // histogram manager if one is available for the chosen excluded volume method. Set by the rigid-body
+        // machinery, which recalculates after every transformation. Unlike symmetry-awareness - which is derived
+        // from the molecule itself - this cannot be deduced from the data, only from how it is going to be used.
+        static bool prefer_partial_manager;
     };
 }

--- a/source/core/hist/histogram_manager/HistogramManagerFactory.cpp
+++ b/source/core/hist/histogram_manager/HistogramManagerFactory.cpp
@@ -25,18 +25,46 @@
 using namespace ausaxs;
 using namespace ausaxs::hist::factory;
 
+namespace {
+    bool is_partial(settings::hist::HistogramManagerChoice choice) {
+        switch (choice) {
+            case settings::hist::HistogramManagerChoice::PartialHistogramManager:
+            case settings::hist::HistogramManagerChoice::PartialHistogramManagerMT:
+            case settings::hist::HistogramManagerChoice::PartialHistogramSymmetryManagerMT:
+                return true;
+            default:
+                return false;
+        }
+    }
+}
+
 std::unique_ptr<hist::IHistogramManager> hist::factory::construct_histogram_manager(
     observer_ptr<const data::Molecule> protein, bool weighted_bins, bool variable_bin_width
 ) {
     auto choice = settings::hist::get_histogram_manager();
-    bool has_syms = protein->symmetry().has_symmetries();
-    if (has_syms) {
+
+    // partial and symmetry-aware implementations exist only for the plain manager family, so both preferences below
+    // may have to be dropped. Say so rather than silently handing back a manager that quietly does the wrong thing:
+    // an ignored symmetry changes the result, and an ignored partial preference changes only the running time - but
+    // by a lot, since the caller asking for one is by definition recalculating in a loop.
+    if (settings::flags::prefer_partial_manager && !is_partial(choice)) {
+        console::print_warning(
+            "construct_histogram_manager: A partial histogram manager was requested, but the chosen excluded volume method "
+            "has no partial implementation. Every update will recalculate the full histogram. "
+        );
+    }
+
+    if (protein->symmetry().has_symmetries()) {
         switch (choice) {
             case settings::hist::HistogramManagerChoice::HistogramManager:
             case settings::hist::HistogramManagerChoice::HistogramManagerMT:
                 choice = settings::hist::HistogramManagerChoice::HistogramSymmetryManagerMT;
                 break;
-            default: 
+            case settings::hist::HistogramManagerChoice::PartialHistogramManager:
+            case settings::hist::HistogramManagerChoice::PartialHistogramManagerMT:
+                choice = settings::hist::HistogramManagerChoice::PartialHistogramSymmetryManagerMT;
+                break;
+            default:
                 console::print_warning(
                     "construct_histogram_manager: Molecule contains symmetries, but the chosen excluded volume method does not support them. "
                     "Symmetries will be ignored. "

--- a/source/core/hist/histogram_manager/HistogramManagerFactory.cpp
+++ b/source/core/hist/histogram_manager/HistogramManagerFactory.cpp
@@ -42,15 +42,10 @@ std::unique_ptr<hist::IHistogramManager> hist::factory::construct_histogram_mana
     observer_ptr<const data::Molecule> protein, bool weighted_bins, bool variable_bin_width
 ) {
     auto choice = settings::hist::get_histogram_manager();
-
-    // partial and symmetry-aware implementations exist only for the plain manager family, so both preferences below
-    // may have to be dropped. Say so rather than silently handing back a manager that quietly does the wrong thing:
-    // an ignored symmetry changes the result, and an ignored partial preference changes only the running time - but
-    // by a lot, since the caller asking for one is by definition recalculating in a loop.
     if (settings::flags::prefer_partial_manager && !is_partial(choice)) {
         console::print_warning(
-            "construct_histogram_manager: A partial histogram manager was requested, but the chosen excluded volume method "
-            "has no partial implementation. Every update will recalculate the full histogram. "
+            "construct_histogram_manager: A partial histogram manager was requested, but the chosen excluded volume method has no partial implementation. "
+            "Every update will recalculate the full histogram."
         );
     }
 

--- a/source/core/settings/Flags.cpp
+++ b/source/core/settings/Flags.cpp
@@ -11,3 +11,4 @@ char flags::last_parsed_unit = ' ';
 bool flags::init_histogram_manager = true;
 bool flags::custom_bin_width = false;
 double flags::inv_bin_width = 1./constants::axes::d_axis.width();
+bool flags::prefer_partial_manager = false;

--- a/source/core/settings/HistogramSettings.cpp
+++ b/source/core/settings/HistogramSettings.cpp
@@ -100,10 +100,6 @@ namespace ausaxs::settings::io {
 }
 
 namespace {
-    // The plain manager family is the only one with partial implementations, so it is also the only place where
-    // settings::flags::prefer_partial_manager can be honoured. Callers that ask for a partial manager under any
-    // other excluded volume method are warned and given the full one by hist::factory::construct_histogram_manager,
-    // which - unlike this getter - is called once per manager rather than on every query.
     settings::hist::HistogramManagerChoice plain_manager() {
         using Choice = settings::hist::HistogramManagerChoice;
         bool st = settings::general::threads == 1; // if no multi-threading is enabled, switch to the single-threaded manager

--- a/source/core/settings/HistogramSettings.cpp
+++ b/source/core/settings/HistogramSettings.cpp
@@ -99,13 +99,25 @@ namespace ausaxs::settings::io {
     });
 }
 
+namespace {
+    // The plain manager family is the only one with partial implementations, so it is also the only place where
+    // settings::flags::prefer_partial_manager can be honoured. Callers that ask for a partial manager under any
+    // other excluded volume method are warned and given the full one by hist::factory::construct_histogram_manager,
+    // which - unlike this getter - is called once per manager rather than on every query.
+    settings::hist::HistogramManagerChoice plain_manager() {
+        using Choice = settings::hist::HistogramManagerChoice;
+        bool st = settings::general::threads == 1; // if no multi-threading is enabled, switch to the single-threaded manager
+        if (settings::flags::prefer_partial_manager) {
+            return st ? Choice::PartialHistogramManager : Choice::PartialHistogramManagerMT;
+        }
+        return st ? Choice::HistogramManager : Choice::HistogramManagerMT;
+    }
+}
+
 settings::hist::HistogramManagerChoice settings::hist::get_histogram_manager() {
     switch (settings::exv::exv_method) {
         case settings::exv::ExvMethod::Simple:
-            // if no multi-threading is enabled, switch to the single-threaded manager
-            return settings::general::threads == 1 
-                ? settings::hist::HistogramManagerChoice::HistogramManager 
-                : settings::hist::HistogramManagerChoice::HistogramManagerMT;
+            return plain_manager();
 
         case settings::exv::ExvMethod::Average: 
             return settings::hist::HistogramManagerChoice::HistogramManagerMTFFAvg;
@@ -139,9 +151,7 @@ settings::hist::HistogramManagerChoice settings::hist::get_histogram_manager() {
 
         case settings::exv::ExvMethod::None:
             ausaxs::hist::detail::SimpleExvModel::disable();
-            return settings::general::threads == 1 
-                ? settings::hist::HistogramManagerChoice::HistogramManager 
-                : settings::hist::HistogramManagerChoice::HistogramManagerMT;
+            return plain_manager();
 
         default:
             throw except::unexpected("settings::hist::get_histogram_manager: Unknown ExvMethod. Did you forget to add it to the switch statement?");

--- a/source/rigidbody/Rigidbody.cpp
+++ b/source/rigidbody/Rigidbody.cpp
@@ -30,10 +30,6 @@ Rigidbody::Rigidbody(data::Molecule&& _molecule) : molecule(std::move(_molecule)
         }
     }
 
-    // the optimiser recalculates after every transformation, so a partial manager is always the right choice here.
-    // The flag is process-global, but partial vs. full is a pure performance tradeoff with identical results, so
-    // leaking it into other molecules in the same process is harmless. Setting it on the instance rather than at
-    // program boot keeps the guarantee for every Rigidbody, however it was constructed.
     settings::flags::prefer_partial_manager = true;
     molecule.reset_histogram_manager();
     constraints = std::make_unique<constraints::ConstraintManager>(this);

--- a/source/rigidbody/Rigidbody.cpp
+++ b/source/rigidbody/Rigidbody.cpp
@@ -14,6 +14,7 @@
 #include <data/Molecule.h>
 #include <data/Body.h>
 #include <grid/Grid.h>
+#include <settings/Flags.h>
 #include <utility/Logging.h>
 
 using namespace ausaxs::rigidbody;
@@ -29,7 +30,12 @@ Rigidbody::Rigidbody(data::Molecule&& _molecule) : molecule(std::move(_molecule)
         }
     }
 
-    molecule.set_histogram_manager(settings::hist::HistogramManagerChoice::PartialHistogramManagerMT);
+    // the optimiser recalculates after every transformation, so a partial manager is always the right choice here.
+    // The flag is process-global, but partial vs. full is a pure performance tradeoff with identical results, so
+    // leaking it into other molecules in the same process is harmless. Setting it on the instance rather than at
+    // program boot keeps the guarantee for every Rigidbody, however it was constructed.
+    settings::flags::prefer_partial_manager = true;
+    molecule.reset_histogram_manager();
     constraints = std::make_unique<constraints::ConstraintManager>(this);
     conformation = std::make_unique<rigidbody::detail::SystemSpecification>(this);
     controller = factory::create_controller(this);

--- a/source/rigidbody/sequencer/elements/setup/ConvertToSymmetryElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/ConvertToSymmetryElement.cpp
@@ -16,7 +16,6 @@
 #include <data/symmetry/CyclicSymmetry.h>
 #include <data/symmetry/IPolyhedralSymmetry.h>
 #include <data/symmetry/CompositeSymmetry.h>
-#include <hist/histogram_manager/PartialSymmetryManagerMT.h>
 #include <settings/GeneralSettings.h>
 #include <data/Molecule.h>
 #include <data/Body.h>
@@ -138,7 +137,7 @@ void ConvertToSymmetryElement::_convert(const std::vector<int>& bodies, const st
 
     // rebuild the (now symmetry-aware) histogram manager for the reduced body set; this also rebinds the body signallers. The grid must be rebuilt 
     // since the atom count changed.
-    molecule->set_histogram_manager(std::make_unique<hist::PartialSymmetryManagerMT<true, false>>(molecule));
+    molecule->reset_histogram_manager();
     rigidbody->molecule.clear_grid();
     rigidbody->refresh_grid();
 }

--- a/source/rigidbody/sequencer/elements/setup/SymmetryElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/SymmetryElement.cpp
@@ -11,8 +11,6 @@
 #include <data/symmetry/CompositeSymmetry.h>
 #include <data/symmetry/CyclicSymmetry.h>
 #include <data/symmetry/ReferenceSymmetry.h>
-#include <hist/histogram_manager/PartialSymmetryManagerMT.h>
-#include <settings/HistogramSettings.h>
 #include <data/Molecule.h>
 #include <data/Body.h>
 
@@ -74,7 +72,6 @@ void SymmetryElement::_add(const std::vector<std::string>& names, std::vector<st
     auto rigidbody = owner->_get_rigidbody();
     auto& setup = owner->setup();
 
-    molecule->set_histogram_manager(std::make_unique<hist::PartialSymmetryManagerMT<true, false>>(molecule));
     for (unsigned int i = 0; i < names.size(); ++i) {
         int ibody = setup._get_body(names[i]);
 
@@ -99,7 +96,11 @@ void SymmetryElement::_add(const std::vector<std::string>& names, std::vector<st
             molecule->get_body(ibody).symmetry().get(isymmetry)->clone()
         );
     }
-    // Adding symmetry changes the body atom count, so the grid must be fully rebuilt
+
+    // rebuild the histogram manager now that the symmetries are in place, so the factory can see them and pick the
+    // symmetry-aware implementation itself; this also rebinds the body signallers. Adding symmetry changes the body
+    // atom count, so the grid must be fully rebuilt too.
+    molecule->reset_histogram_manager();
     rigidbody->molecule.clear_grid();
     rigidbody->refresh_grid();
 }
@@ -109,8 +110,6 @@ void SymmetryElement::_add_reference(const std::vector<std::string>& body_names,
     auto molecule = owner->_get_molecule();
     auto rigidbody = owner->_get_rigidbody();
     auto& setup = owner->setup();
-
-    molecule->set_histogram_manager(std::make_unique<hist::PartialSymmetryManagerMT<true, false>>(molecule));
 
     // resolve the participating body indices, preserving the declared order (first = primary)
     std::vector<int> bodies;
@@ -173,7 +172,9 @@ void SymmetryElement::_add_reference(const std::vector<std::string>& body_names,
         );
     }
 
-    // Adding symmetry changes the body atom count, so the grid must be fully rebuilt
+    // as in _add: rebuild the manager once the symmetries exist so the factory can select the symmetry-aware
+    // implementation, then rebuild the grid for the changed atom count
+    molecule->reset_histogram_manager();
     rigidbody->molecule.clear_grid();
     rigidbody->refresh_grid();
 }

--- a/source/rigidbody/sequencer/elements/setup/SymmetryElement.cpp
+++ b/source/rigidbody/sequencer/elements/setup/SymmetryElement.cpp
@@ -81,8 +81,8 @@ void SymmetryElement::_add(const std::vector<std::string>& names, std::vector<st
         molecule->get_body(ibody).symmetry().add(symmetries[i]->clone());
         rigidbody->conformation->initial_conformation[ibody].symmetry().add(std::move(symmetries[i]));
 
-        // add names for the symmetric bodies: each replica's permanent tag is always "bXsYrZ", built from the body's own index rather than whatever name the caller 
-        // used to refer to it, so it stays valid no matter how the base body gets renamed later
+        // add names for the symmetric bodies: each replica's permanent tag is always "bXsYrZ", built from the body's own index rather than whatever name 
+        // the caller used to refer to it, so it stays valid no matter how the base body gets renamed later
         auto& name_map = setup._body_name_registry();
         int isymmetry = molecule->get_body(ibody).size_symmetry()-1;
         assert(0 <= isymmetry && "SymmetryElement::_add: Inconsistent data structures.");
@@ -97,9 +97,8 @@ void SymmetryElement::_add(const std::vector<std::string>& names, std::vector<st
         );
     }
 
-    // rebuild the histogram manager now that the symmetries are in place, so the factory can see them and pick the
-    // symmetry-aware implementation itself; this also rebinds the body signallers. Adding symmetry changes the body
-    // atom count, so the grid must be fully rebuilt too.
+    // rebuild the histogram manager now that the symmetries are in place, so the factory can see them and pick the symmetry-aware implementation itself; this 
+    // also rebinds the body signallers. Adding symmetry changes the body atom count, so the grid must be fully rebuilt too.
     molecule->reset_histogram_manager();
     rigidbody->molecule.clear_grid();
     rigidbody->refresh_grid();
@@ -132,8 +131,7 @@ void SymmetryElement::_add_reference(const std::vector<std::string>& body_names,
     }
     int primary_slot = slots.front();
 
-    // the primary body owns the shared ReferenceSymmetry; install it on the live molecule and
-    // the stored initial conformation
+    // the primary body owns the shared ReferenceSymmetry; install it on the live molecule and the stored initial conformation
     enable_optimization(molecule->get_body(primary).symmetry().get_obj());
     enable_optimization(rigidbody->conformation->initial_conformation[primary].symmetry().get_obj());
     molecule->get_body(primary).symmetry().add(std::make_unique<symmetry::ReferenceSymmetry>(*cyclic, bodies, slots, molecule));
@@ -172,8 +170,8 @@ void SymmetryElement::_add_reference(const std::vector<std::string>& body_names,
         );
     }
 
-    // as in _add: rebuild the manager once the symmetries exist so the factory can select the symmetry-aware
-    // implementation, then rebuild the grid for the changed atom count
+    // as in _add: rebuild the manager once the symmetries exist so the factory can select the symmetry-aware implementation, then rebuild the grid for the 
+    // changed atom count
     molecule->reset_histogram_manager();
     rigidbody->molecule.clear_grid();
     rigidbody->refresh_grid();
@@ -212,8 +210,7 @@ std::unique_ptr<GenericElement> SymmetryElement::_parse(observer_ptr<LoopElement
     // symmetry {
     //    bodies "b1 b2 b3" c3
     // }
-    // the listed bodies (whitespace-separated, optionally quoted as one token) are replicated
-    // together; the trailing value is the shared symmetry name.
+    // the listed bodies (whitespace-separated, optionally quoted as one token) are replicated together; the trailing value is the shared symmetry name.
     if (auto it = args.named.find("bodies"); it != args.named.end()) {
         if (args.named.size() != 1) {throw except::parse_error("symmetry", "The \"bodies\" reference form cannot be combined with other symmetry directives.");}
         const auto& value = it->second;

--- a/tests/feature/hist/histogram_manager_factory.cpp
+++ b/tests/feature/hist/histogram_manager_factory.cpp
@@ -12,6 +12,11 @@
 #include <hist/histogram_manager/PartialHistogramManager.h>
 #include <hist/histogram_manager/PartialHistogramManagerMT.h>
 #include <hist/histogram_manager/PartialSymmetryManagerMT.h>
+#include <data/Molecule.h>
+#include <data/Body.h>
+#include <data/symmetry/BodySymmetryFacade.h>
+#include <data/symmetry/PredefinedSymmetries.h>
+#include <settings/All.h>
 
 #include "hist_test_helper.h"
 
@@ -32,6 +37,54 @@ template<> constexpr settings::hist::HistogramManagerChoice choice_for<hist::Par
 template<> constexpr settings::hist::HistogramManagerChoice choice_for<hist::HistogramManagerMTFFGrid>() {return settings::hist::HistogramManagerChoice::HistogramManagerMTFFGrid;}
 template<> constexpr settings::hist::HistogramManagerChoice choice_for<hist::HistogramManagerMTFFGridSurface>() {return settings::hist::HistogramManagerChoice::HistogramManagerMTFFGridSurface;}
 template<> constexpr settings::hist::HistogramManagerChoice choice_for<hist::HistogramManagerMTFFGridScalableExv>() {return settings::hist::HistogramManagerChoice::HistogramManagerMTFFGridScalableExv;}
+
+TEST_CASE("HistogramManagerFactory: resolves partial and symmetry preferences") {
+    auto exv = settings::exv::exv_method;
+    auto threads = settings::general::threads;
+    auto prefer_partial = settings::flags::prefer_partial_manager;
+    settings::exv::exv_method = settings::exv::ExvMethod::Simple;
+    settings::general::threads = 4;
+    settings::hist::weighted_bins = true;
+    settings::flags::custom_bin_width = false;
+
+    Molecule plain({Body{SimpleCube::get_atoms()}});
+
+    Molecule symmetric({Body{SimpleCube::get_atoms()}});
+    symmetric.get_body(0).symmetry().add(symmetry::type::c2);
+    REQUIRE(symmetric.symmetry().has_symmetries());
+
+    SECTION("without a partial preference") {
+        settings::flags::prefer_partial_manager = false;
+
+        // symmetry-awareness is derived from the molecule, never from a setting
+        CHECK(dynamic_cast<hist::HistogramManagerMT<true, false>*>(hist::factory::construct_histogram_manager(&plain).get()) != nullptr);
+        CHECK(dynamic_cast<hist::SymmetryManagerMT<true, false>*>(hist::factory::construct_histogram_manager(&symmetric).get()) != nullptr);
+    }
+
+    SECTION("with a partial preference") {
+        settings::flags::prefer_partial_manager = true;
+
+        CHECK(dynamic_cast<hist::PartialHistogramManagerMT<true, false>*>(hist::factory::construct_histogram_manager(&plain).get()) != nullptr);
+        CHECK(dynamic_cast<hist::PartialSymmetryManagerMT<true, false>*>(hist::factory::construct_histogram_manager(&symmetric).get()) != nullptr);
+
+        // the single-threaded partial manager has no symmetry-aware counterpart, so it upgrades to the MT one
+        settings::general::threads = 1;
+        CHECK(dynamic_cast<hist::PartialHistogramManager<true, false>*>(hist::factory::construct_histogram_manager(&plain).get()) != nullptr);
+        CHECK(dynamic_cast<hist::PartialSymmetryManagerMT<true, false>*>(hist::factory::construct_histogram_manager(&symmetric).get()) != nullptr);
+    }
+
+    SECTION("preference is dropped when the excluded volume method has no partial implementation") {
+        settings::flags::prefer_partial_manager = true;
+        settings::exv::exv_method = settings::exv::ExvMethod::Fraser;
+
+        // the excluded volume model wins: it changes the result, whereas dropping the partial preference only costs time
+        CHECK(dynamic_cast<hist::HistogramManagerMTFFExplicit<true, false>*>(hist::factory::construct_histogram_manager(&plain).get()) != nullptr);
+    }
+
+    settings::exv::exv_method = exv;
+    settings::general::threads = threads;
+    settings::flags::prefer_partial_manager = prefer_partial;
+}
 
 TEST_CASE("HistogramManagerFactory: creates expected manager") {
     Molecule protein({Body{SimpleCube::get_atoms()}});


### PR DESCRIPTION
Multiple elements require updating the histogram manager to one that respects symmetries. This was previously done by manually updating the manager, which creates inconsistencies with respect to the global settings. 

This PR fixes this issue by: 
i) adding a new global flag for preferring partial managers, and
ii) resetting the manager after every symmetry construction, which now automatically picks up the symmetry-enabled manager.